### PR TITLE
Make daemon/run work on Linux

### DIFF
--- a/core/src/main/scala/commandcenter/CCConfig.scala
+++ b/core/src/main/scala/commandcenter/CCConfig.scala
@@ -27,10 +27,11 @@ object CCConfig {
 
   def loadFrom(config: Config): Task[CCConfig] =
     for {
-      commands      <- CommandPlugin.load(config, "commands")
-      aliases       <- Task.fromEither(config.as[Map[String, List[String]]]("aliases"))
-      displayConfig <- Task.fromEither(config.as[DisplayConfig]("display"))
-    } yield CCConfig(commands.toVector, aliases, displayConfig)
+      commands       <- CommandPlugin.load(config, "commands")
+      aliases        <- Task.fromEither(config.as[Map[String, List[String]]]("aliases"))
+      displayConfig  <- Task.fromEither(config.as[DisplayConfig]("display"))
+      keyboardConfig <- Task.fromEither(config.as[KeyboardConfig]("keyboard"))
+    } yield CCConfig(commands.toVector, aliases, displayConfig, keyboardConfig)
 
   private def envConfigFile: Option[File] =
     sys.env
@@ -50,7 +51,8 @@ object CCConfig {
 final case class CCConfig(
   commands: Vector[Command[Any]],
   aliases: Map[String, List[String]],
-  display: DisplayConfig
+  display: DisplayConfig,
+  keyboard: KeyboardConfig
 )
 
 final case class DisplayConfig(width: Int, maxHeight: Int, opacity: Float, fonts: List[Font])
@@ -60,4 +62,8 @@ object DisplayConfig {
     Decoder.forProduct4("width", "maxHeight", "opacity", "fonts")(DisplayConfig.apply)
 }
 
-final case class KeyboardConfig()
+final case class KeyboardConfig(openShortcut: String)
+
+object KeyboardConfig {
+  implicit val decoder: Decoder[KeyboardConfig] = Decoder.forProduct1("openShortcut")(KeyboardConfig.apply)
+}

--- a/core/src/main/scala/commandcenter/util/GraphicsUtil.scala
+++ b/core/src/main/scala/commandcenter/util/GraphicsUtil.scala
@@ -1,0 +1,13 @@
+package commandcenter.util
+
+import java.awt.{ GraphicsDevice, GraphicsEnvironment }
+
+import zio.{ Task, UIO }
+
+object GraphicsUtil {
+  def isOpacitySupported: UIO[Boolean] =
+    Task(
+      GraphicsEnvironment.getLocalGraphicsEnvironment.getDefaultScreenDevice
+        .isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.TRANSLUCENT)
+    ).orElseSucceed(false)
+}

--- a/daemon/src/main/scala/commandcenter/daemon/Main.scala
+++ b/daemon/src/main/scala/commandcenter/daemon/Main.scala
@@ -14,7 +14,7 @@ object Main extends CCApp {
       config   <- CCConfig.load.toManaged_
       terminal <- SwingTerminal.create(config, this)
       _        <- (for {
-                      _ <- provider.registerHotKey(JKeyStroke.getKeyStroke("meta SPACE"))(_ =>
+                      _ <- provider.registerHotKey(JKeyStroke.getKeyStroke(config.keyboard.openShortcut))(_ =>
                              (for {
                                _ <- log.debug("Opening emulated terminal...")
                                _ <- terminal.open

--- a/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
+++ b/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
@@ -4,12 +4,12 @@ import java.awt.event.KeyEvent
 import java.awt.{ BorderLayout, Color, Dimension, Font, GraphicsEnvironment }
 
 import commandcenter.CCRuntime.Env
+import commandcenter._
 import commandcenter.command.{ Command, CommandResult, PreviewResult, SearchResults }
 import commandcenter.locale.Language
 import commandcenter.ui.CCTheme
-import commandcenter.util.{ Debounced, OS }
+import commandcenter.util.{ Debounced, GraphicsUtil, OS }
 import commandcenter.view.AnsiRendered
-import commandcenter._
 import javax.swing._
 import javax.swing.plaf.basic.BasicScrollBarUI
 import javax.swing.text.{ DefaultStyledDocument, StyleConstants, StyleContext }
@@ -38,7 +38,8 @@ final case class SwingTerminal(
 
   frame.setBackground(theme.background)
   frame.setUndecorated(true)
-  frame.setOpacity(config.display.opacity)
+  if (runtime.unsafeRun(GraphicsUtil.isOpacitySupported))
+    frame.setOpacity(config.display.opacity)
   frame.getContentPane.setLayout(new BorderLayout())
 
   val inputTextField = new ZTextField


### PR DESCRIPTION
...or at least on my box. These are small so I group them together:

1. Make keyboard shortcut configurable: we have a config for it, but it's not picked up.
2. Change default display opacity in `application.conf` to 1.0: because to set it lower requires [The TRANSLUCENT translucency must be supported by the underlying system](https://docs.oracle.com/javase/7/docs/api/java/awt/Frame.html#setOpacity(float)).