### PR TITLE
Add CommandSpec and example usage

### DIFF
--- a/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
+++ b/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
@@ -84,7 +84,7 @@ final case class CliTerminal[T <: Terminal](
       new KeyStroke(KeyType.ArrowDown) -> (
         for {
           previousResults <- searchResultsRef.get
-          _               <- commandCursorRef.update(cursor => (cursor + 1) min (previousResults.results.length - 1))
+          _               <- commandCursorRef.update(cursor => (cursor + 1) min (previousResults.previews.length - 1))
         } yield EventResult.Success
       ),
       new KeyStroke(KeyType.ArrowUp) -> commandCursorRef.update(cursor => (cursor - 1) max 0).as(EventResult.Success),
@@ -140,7 +140,7 @@ final case class CliTerminal[T <: Terminal](
       rows          = size.getRows
       columns       = size.getColumns
       _             <- ZIO.foldLeft(results.rendered.take(rows - 1))(Cursor(prompt.length, 1))((s, r) => printRendered(r, s))
-      _ <- Task.when(results.results.nonEmpty) {
+      _ <- Task.when(results.previews.nonEmpty) {
             Task {
               val cursorRow = commandCursor + 1
 
@@ -177,7 +177,7 @@ final case class CliTerminal[T <: Terminal](
 
   def runSelected(results: SearchResults[Any], cursorIndex: Int): RIO[Env, Option[PreviewResult[Any]]] =
     for {
-      previewResult <- ZIO.fromOption(results.results.lift(cursorIndex)).option
+      previewResult <- ZIO.fromOption(results.previews.lift(cursorIndex)).option
       _             <- ZIO.fromOption(previewResult).flatMap(_.onRun).either.forkDaemon
       _             <- reset()
     } yield previewResult

--- a/core/src/main/scala/commandcenter/TerminalType.scala
+++ b/core/src/main/scala/commandcenter/TerminalType.scala
@@ -7,6 +7,7 @@ sealed trait TerminalType extends EnumEntry
 object TerminalType extends Enum[TerminalType] {
   case object Cli   extends TerminalType
   case object Swing extends TerminalType
+  case object Test  extends TerminalType
 
   override def values: IndexedSeq[TerminalType] = findValues
 }

--- a/core/src/main/scala/commandcenter/command/Command.scala
+++ b/core/src/main/scala/commandcenter/command/Command.scala
@@ -40,12 +40,12 @@ trait Command[+R] extends ViewInstances {
 }
 
 object Command {
-  def search(
-    commands: Vector[Command[Any]],
+  def search[A](
+    commands: Vector[Command[A]],
     aliases: Map[String, List[String]],
     input: String,
     terminal: CCTerminal
-  ): URIO[Env, SearchResults[Any]] = {
+  ): URIO[Env, SearchResults[A]] = {
     val context = CommandContext(Language.detect(input), terminal, 1.0)
 
     val (commandPart, rest) = input.split("[ ]+", 2) match {
@@ -62,7 +62,7 @@ object Command {
       }(_.option) // TODO: Use `.either` here and log errors instead of ignoring them
       .map { r =>
         val results = r.flatten.flatten.sortBy(_.score)(Ordering.Double.TotalOrdering.reverse)
-        
+
         SearchResults(input, results.toVector)
       }
   }

--- a/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
@@ -1,9 +1,11 @@
 package commandcenter.command
 
+import java.util.concurrent.TimeUnit
+
 import commandcenter.CCRuntime.Env
 import commandcenter.util.ProcessUtil
 import io.circe.Decoder
-import zio.{ UIO, ZIO }
+import zio.{ clock, ZIO }
 
 final case class EpochMillisCommand() extends Command[Long] {
   val commandType: CommandType = CommandType.EpochMillisCommand
@@ -15,7 +17,7 @@ final case class EpochMillisCommand() extends Command[Long] {
   def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Long]]] =
     for {
       input     <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-      epochTime <- UIO(System.currentTimeMillis())
+      epochTime <- clock.currentTime(TimeUnit.MILLISECONDS)
     } yield List(
       Preview(epochTime)
         .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
@@ -1,9 +1,11 @@
 package commandcenter.command
 
+import java.util.concurrent.TimeUnit
+
 import commandcenter.CCRuntime.Env
 import commandcenter.util.ProcessUtil
 import io.circe.Decoder
-import zio.{ UIO, ZIO }
+import zio.{ clock, ZIO }
 
 final case class EpochUnixCommand() extends Command[Long] {
   val commandType: CommandType = CommandType.EpochUnixCommand
@@ -15,7 +17,7 @@ final case class EpochUnixCommand() extends Command[Long] {
   def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Long]]] =
     for {
       input     <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-      epochTime <- UIO(System.currentTimeMillis() / 1000)
+      epochTime <- clock.currentTime(TimeUnit.SECONDS)
     } yield {
       List(
         Preview(epochTime)

--- a/core/src/main/scala/commandcenter/command/SearchResults.scala
+++ b/core/src/main/scala/commandcenter/command/SearchResults.scala
@@ -2,8 +2,8 @@ package commandcenter.command
 
 import commandcenter.view.Rendered
 
-final case class SearchResults[R](searchTerm: String, results: Vector[PreviewResult[R]]) {
-  lazy val rendered: Vector[Rendered] = results.map(_.renderFn())
+final case class SearchResults[R](searchTerm: String, previews: Vector[PreviewResult[R]]) {
+  lazy val rendered: Vector[Rendered] = previews.map(_.renderFn())
 
   def hasChange(otherSearchTerm: String): Boolean =
     searchTerm.trim != otherSearchTerm.trim

--- a/core/src/test/scala/commandcenter/CommandSpec.scala
+++ b/core/src/test/scala/commandcenter/CommandSpec.scala
@@ -1,0 +1,20 @@
+package commandcenter
+
+import commandcenter.TestRuntime.TestEnv
+import sttp.client.asynchttpclient.zio.AsyncHttpClientZioBackend
+import zio.duration._
+import zio.logging.Logging
+import zio.test.environment.testEnvironment
+import zio.test.{ RunnableSpec, TestAspect, TestExecutor, TestRunner }
+import zio.{ Layer, ZEnv }
+
+trait CommandSpec extends RunnableSpec[TestEnv, Any] {
+  val testEnv: Layer[Throwable, TestEnv] =
+    testEnvironment ++ (ZEnv.live >>> Logging.console((_, logEntry) => logEntry)) ++ AsyncHttpClientZioBackend.layer()
+
+  override def aspects: List[TestAspect[Nothing, TestEnv, Nothing, Any]] =
+    List(TestAspect.timeoutWarning(60.seconds))
+
+  override def runner: TestRunner[TestEnv, Any] =
+    TestRunner(TestExecutor.default(testEnv.orDie))
+}

--- a/core/src/test/scala/commandcenter/TestRuntime.scala
+++ b/core/src/test/scala/commandcenter/TestRuntime.scala
@@ -1,0 +1,20 @@
+package commandcenter
+
+import sttp.client.asynchttpclient.zio.SttpClient
+import zio.ZEnv
+import zio.logging.Logging
+import zio.test.environment._
+import zio.test.{ Annotations, Sized }
+
+object TestRuntime {
+  type TestEnv = ZEnv
+    with Annotations
+    with TestClock
+    with TestConsole
+    with Live
+    with TestRandom
+    with Sized
+    with TestSystem
+    with Logging
+    with SttpClient
+}

--- a/core/src/test/scala/commandcenter/TestTerminal.scala
+++ b/core/src/test/scala/commandcenter/TestTerminal.scala
@@ -1,0 +1,20 @@
+package commandcenter
+
+import java.awt.Dimension
+
+import commandcenter.CCRuntime.Env
+import zio.{ RIO, UIO, ZIO }
+
+object TestTerminal extends CCTerminal {
+  def terminalType: TerminalType = TerminalType.Test
+
+  def opacity: RIO[Env, Float] = UIO(1.0f)
+
+  def setOpacity(opacity: Float): RIO[Env, Unit] = ZIO.unit
+
+  def size: RIO[Env, Dimension] = UIO(new Dimension(80, 40))
+
+  def setSize(width: Int, height: Int): RIO[Env, Unit] = ZIO.unit
+
+  def reload: RIO[Env, Unit] = ZIO.unit
+}

--- a/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
+++ b/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
@@ -1,0 +1,28 @@
+package commandcenter.command
+
+import commandcenter.{ CommandSpec, TestTerminal }
+import zio.duration._
+import zio.test.Assertion._
+import zio.test._
+import zio.test.environment.TestClock
+
+object EpochMillisCommandSpec extends CommandSpec {
+  val command: EpochMillisCommand = EpochMillisCommand()
+
+  def spec =
+    suite("EpochMillisCommandSpec")(
+      testM("get current time") {
+        val results = Command.search(Vector(command), Map.empty, "epoch", TestTerminal)
+
+        for {
+          _        <- TestClock.setTime(5.seconds)
+          previews <- results.map(_.previews)
+        } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo(5000L))))
+      },
+      testM("return nothing for non-matching search") {
+        val results = Command.search(Vector(command), Map.empty, "not matching", TestTerminal)
+
+        assertM(results.map(_.previews))(isEmpty)
+      }
+    )
+}

--- a/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
+++ b/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
@@ -62,7 +62,7 @@ final case class SwingTerminal(
     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
   ) {
     override def getPreferredSize: Dimension = {
-      val height = if (runtime.unsafeRun(searchResultsRef.get).results.isEmpty) {
+      val height = if (runtime.unsafeRun(searchResultsRef.get).previews.isEmpty) {
         0
       } else {
         outputTextPane.getPreferredSize.height min config.display.maxHeight
@@ -172,7 +172,7 @@ final case class SwingTerminal(
 
   def runSelected(results: SearchResults[Any], cursorIndex: Int): RIO[Env, Option[PreviewResult[Any]]] =
     for {
-      previewResult <- ZIO.fromOption(results.results.lift(cursorIndex)).option
+      previewResult <- ZIO.fromOption(results.previews.lift(cursorIndex)).option
       _             <- ZIO.fromOption(previewResult).flatMap(_.onRun).either.forkDaemon
       _             <- reset()
     } yield previewResult
@@ -203,7 +203,7 @@ final case class SwingTerminal(
           for {
             _               <- UIO(e.consume())
             previousResults <- searchResultsRef.get
-            _               <- commandCursorRef.update(cursor => (cursor + 1) min (previousResults.results.length - 1))
+            _               <- commandCursorRef.update(cursor => (cursor + 1) min (previousResults.previews.length - 1))
             _               <- render(previousResults)
           } yield ()
 


### PR DESCRIPTION
This adds a `CommandSpec` trait which creates the test environment. Each Command can have its own spec file extending this trait. I added a small example with `EpochMillisCommandSpec`.

@tuleism If you're going to use it for the Maven command, feel free to change `testEnv` to use the mock sttp client rather than the live one so you don't make real http requests.