### PR TITLE
Switch to httpclient-backend-zio

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,20 +21,20 @@ lazy val core = module("core")
   .settings(
     resolvers := Resolvers,
     libraryDependencies ++= Seq(
-      "dev.zio"                      %% "zio"                           % Version.zio,
-      "dev.zio"                      %% "zio-streams"                   % Version.zio,
-      "dev.zio"                      %% "zio-process"                   % "0.0.6",
-      "dev.zio"                      %% "zio-logging"                   % "0.3.2",
-      "io.circe"                     %% "circe-config"                  % "0.8.0",
-      "org.scala-lang"               % "scala-reflect"                  % "2.13.3",
-      "io.circe"                     %% "circe-core"                    % Version.circe,
-      "io.circe"                     %% "circe-parser"                  % Version.circe,
-      "com.monovore"                 %% "decline"                       % "1.2.0",
-      "com.lihaoyi"                  %% "fansi"                         % "0.2.9",
-      "com.beachape"                 %% "enumeratum"                    % "1.6.1",
-      "com.softwaremill.sttp.client" %% "core"                          % Version.sttp,
-      "com.softwaremill.sttp.client" %% "circe"                         % Version.sttp,
-      "com.softwaremill.sttp.client" %% "async-http-client-backend-zio" % Version.sttp
+      "dev.zio"                      %% "zio"                    % Version.zio,
+      "dev.zio"                      %% "zio-streams"            % Version.zio,
+      "dev.zio"                      %% "zio-process"            % "0.0.6",
+      "dev.zio"                      %% "zio-logging"            % "0.3.2",
+      "io.circe"                     %% "circe-config"           % "0.8.0",
+      "org.scala-lang"               % "scala-reflect"           % "2.13.3",
+      "io.circe"                     %% "circe-core"             % Version.circe,
+      "io.circe"                     %% "circe-parser"           % Version.circe,
+      "com.monovore"                 %% "decline"                % "1.2.0",
+      "com.lihaoyi"                  %% "fansi"                  % "0.2.9",
+      "com.beachape"                 %% "enumeratum"             % "1.6.1",
+      "com.softwaremill.sttp.client" %% "core"                   % Version.sttp,
+      "com.softwaremill.sttp.client" %% "circe"                  % Version.sttp,
+      "com.softwaremill.sttp.client" %% "httpclient-backend-zio" % Version.sttp
     )
   )
 
@@ -63,7 +63,8 @@ lazy val cliClient = module("cli-client")
       "-H:+TraceClassInitialization",
       "-H:IncludeResources=core/src/main/resources/*",
       "--initialize-at-build-time",
-      "--no-fallback"
+      "--no-fallback",
+      "--enable-https"
     )
   )
   .enablePlugins(GraalVMNativeImagePlugin, JavaServerAppPackaging)

--- a/core/src/main/scala/commandcenter/CCRuntime.scala
+++ b/core/src/main/scala/commandcenter/CCRuntime.scala
@@ -1,14 +1,18 @@
 package commandcenter
 
 import commandcenter.CCRuntime.Env
-import sttp.client.asynchttpclient.zio.{ AsyncHttpClientZioBackend, SttpClient }
+import sttp.client.httpclient.zio.{ HttpClientZioBackend, SttpClient }
 import zio.internal.Platform
 import zio.logging.Logging
 import zio.{ Runtime, ZEnv }
 
 trait CCRuntime extends Runtime[Env] {
   lazy val runtime: Runtime.Managed[Env] = Runtime.unsafeFromLayer {
-    ZEnv.live ++ (ZEnv.live >>> Logging.console((_, logEntry) => logEntry)) ++ AsyncHttpClientZioBackend.layer()
+    ZEnv.live >>> (
+      ZEnv.live
+        ++ Logging.console((_, logEntry) => logEntry)
+        ++ HttpClientZioBackend.layer()
+    )
   }
 
   lazy val environment: Env   = runtime.environment

--- a/core/src/main/scala/commandcenter/command/SearchMavenCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SearchMavenCommand.scala
@@ -7,7 +7,7 @@ import commandcenter.util.ProcessUtil
 import commandcenter.view.DefaultView
 import io.circe.{ Decoder, Json }
 import sttp.client._
-import sttp.client.asynchttpclient.zio._
+import sttp.client.httpclient.zio._
 import sttp.client.circe._
 import zio.{ IO, ZIO }
 

--- a/core/src/test/scala/commandcenter/CommandSpec.scala
+++ b/core/src/test/scala/commandcenter/CommandSpec.scala
@@ -1,7 +1,7 @@
 package commandcenter
 
 import commandcenter.TestRuntime.TestEnv
-import sttp.client.asynchttpclient.zio.AsyncHttpClientZioBackend
+import sttp.client.httpclient.zio.HttpClientZioBackend
 import zio.duration._
 import zio.logging.Logging
 import zio.test.environment.testEnvironment
@@ -10,7 +10,11 @@ import zio.{ Layer, ZEnv }
 
 trait CommandSpec extends RunnableSpec[TestEnv, Any] {
   val testEnv: Layer[Throwable, TestEnv] =
-    testEnvironment ++ (ZEnv.live >>> Logging.console((_, logEntry) => logEntry)) ++ AsyncHttpClientZioBackend.layer()
+    testEnvironment >>> (
+      testEnvironment
+        ++ Logging.console((_, logEntry) => logEntry)
+        ++ HttpClientZioBackend.layer()
+    )
 
   override def aspects: List[TestAspect[Nothing, TestEnv, Nothing, Any]] =
     List(TestAspect.timeoutWarning(60.seconds))

--- a/core/src/test/scala/commandcenter/TestRuntime.scala
+++ b/core/src/test/scala/commandcenter/TestRuntime.scala
@@ -1,6 +1,6 @@
 package commandcenter
 
-import sttp.client.asynchttpclient.zio.SttpClient
+import sttp.client.httpclient.zio.SttpClient
 import zio.ZEnv
 import zio.logging.Logging
 import zio.test.environment._


### PR DESCRIPTION
Closes #52

Switching to httpclient-backend-zio fixed the Graal native-image build for cli-client. It's a blocking client, which isn't ideal, but it's not like we need incredible throughput or anything.

Maybe we can switch back to an async client someday if we have more options in sttp backends in the future. Or if somebody figures out how to make netty work with native-image.