### PR TITLE
Finish native executable support for cli-client

### DIFF
--- a/core/src/main/scala/commandcenter/CommandContext.scala
+++ b/core/src/main/scala/commandcenter/CommandContext.scala
@@ -2,6 +2,6 @@ package commandcenter
 
 import java.util.Locale
 
-final case class CommandContext(locale: Locale, terminal: CCTerminal, matchScore: Double) {
+final case class CommandContext(locale: Locale, terminal: CCTerminal, ccProcess: CCProcess, matchScore: Double) {
   def matchScore(score: Double): CommandContext = copy(matchScore = score)
 }

--- a/core/src/main/scala/commandcenter/command/Command.scala
+++ b/core/src/main/scala/commandcenter/command/Command.scala
@@ -4,11 +4,10 @@ import java.util.Locale
 
 import com.typesafe.config.Config
 import commandcenter.CCRuntime.Env
-import commandcenter.locale.Language
+import commandcenter.CommandContext
 import commandcenter.util.OS
 import commandcenter.view.syntax._
 import commandcenter.view.{ DefaultView, ViewInstances }
-import commandcenter.{ CCTerminal, CommandContext }
 import io.circe
 import zio._
 
@@ -44,10 +43,8 @@ object Command {
     commands: Vector[Command[A]],
     aliases: Map[String, List[String]],
     input: String,
-    terminal: CCTerminal
+    context: CommandContext
   ): URIO[Env, SearchResults[A]] = {
-    val context = CommandContext(Language.detect(input), terminal, 1.0)
-
     val (commandPart, rest) = input.split("[ ]+", 2) match {
       case Array(prefix, rest) => (prefix, s" $rest")
       case Array(prefix)       => (prefix, "")

--- a/core/src/main/scala/commandcenter/command/DecodeBase64Command.scala
+++ b/core/src/main/scala/commandcenter/command/DecodeBase64Command.scala
@@ -6,7 +6,6 @@ import cats.syntax.apply._
 import com.monovore.decline
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommonOpts._
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.ZIO
 
@@ -24,7 +23,7 @@ final case class DecodeBase64Command() extends Command[String] {
       (valueToDecode, charset) <- ZIO.fromEither(parsedCommand).mapError(CommandError.CliError)
       decoded                  = new String(Base64.getDecoder.decode(valueToDecode.getBytes(charset)), charset)
     } yield {
-      List(Preview(decoded).onRun(ProcessUtil.copyToClipboard(decoded)).score(Scores.high(input.context)))
+      List(Preview(decoded).onRun(input.context.ccProcess.setClipboard(decoded)).score(Scores.high(input.context)))
     }
 }
 

--- a/core/src/main/scala/commandcenter/command/DecodeUrlCommand.scala
+++ b/core/src/main/scala/commandcenter/command/DecodeUrlCommand.scala
@@ -6,7 +6,6 @@ import cats.syntax.apply._
 import com.monovore.decline
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommonOpts._
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.{ IO, Task, ZIO }
 
@@ -23,7 +22,9 @@ final case class DecodeUrlCommand() extends Command[String] {
       parsedCommand            = decline.Command(command, s"URL decodes the given string")(all).parse(input.args)
       (valueToDecode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       decoded                  <- Task(URLDecoder.decode(valueToDecode, charset)).mapError(CommandError.UnexpectedException)
-    } yield List(Preview(decoded).onRun(ProcessUtil.copyToClipboard(decoded)).score(Scores.high(input.context)))
+    } yield List(
+      Preview(decoded).onRun(input.context.ccProcess.setClipboard(decoded)).score(Scores.high(input.context))
+    )
 }
 
 object DecodeUrlCommand extends CommandPlugin[DecodeUrlCommand] {

--- a/core/src/main/scala/commandcenter/command/EncodeBase64Command.scala
+++ b/core/src/main/scala/commandcenter/command/EncodeBase64Command.scala
@@ -6,9 +6,8 @@ import cats.syntax.apply._
 import com.monovore.decline
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommonOpts._
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
-import zio.{ IO, UIO, ZIO }
+import zio.{ IO, ZIO }
 
 final case class EncodeBase64Command() extends Command[String] {
   val command                    = "encodebase64"
@@ -23,7 +22,9 @@ final case class EncodeBase64Command() extends Command[String] {
       parsedCommand            = decline.Command(command, s"Base64 encodes the given string")(all).parse(input.args)
       (valueToEncode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       encoded                  = Base64.getEncoder.encodeToString(valueToEncode.getBytes(charset))
-    } yield List(Preview(encoded).onRun(ProcessUtil.copyToClipboard(encoded)).score(Scores.high(input.context)))
+    } yield List(
+      Preview(encoded).onRun(input.context.ccProcess.setClipboard(encoded)).score(Scores.high(input.context))
+    )
 }
 
 object EncodeBase64Command extends CommandPlugin[EncodeBase64Command] {

--- a/core/src/main/scala/commandcenter/command/EncodeUrlCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EncodeUrlCommand.scala
@@ -6,7 +6,6 @@ import cats.syntax.apply._
 import com.monovore.decline
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommonOpts._
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.{ IO, ZIO }
 
@@ -26,7 +25,7 @@ final case class EncodeUrlCommand() extends Command[String] {
       (valueToEncode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       encoded                  = URLEncoder.encode(valueToEncode, charset)
     } yield List(
-      Preview(encoded).onRun(ProcessUtil.copyToClipboard(encoded)).score(Scores.high(input.context))
+      Preview(encoded).onRun(searchInput.context.ccProcess.setClipboard(encoded)).score(Scores.high(input.context))
     )
 }
 

--- a/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
@@ -3,7 +3,6 @@ package commandcenter.command
 import java.util.concurrent.TimeUnit
 
 import commandcenter.CCRuntime.Env
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.{ clock, ZIO }
 
@@ -21,7 +20,7 @@ final case class EpochMillisCommand() extends Command[Long] {
     } yield List(
       Preview(epochTime)
         .score(Scores.high(input.context))
-        .onRun(ProcessUtil.copyToClipboard(epochTime.toString))
+        .onRun(input.context.ccProcess.setClipboard(epochTime.toString))
     )
 }
 

--- a/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
@@ -3,7 +3,6 @@ package commandcenter.command
 import java.util.concurrent.TimeUnit
 
 import commandcenter.CCRuntime.Env
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.{ clock, ZIO }
 
@@ -22,7 +21,7 @@ final case class EpochUnixCommand() extends Command[Long] {
       List(
         Preview(epochTime)
           .score(Scores.high(input.context))
-          .onRun(ProcessUtil.copyToClipboard(epochTime.toString))
+          .onRun(input.context.ccProcess.setClipboard(epochTime.toString))
       )
     }
 }

--- a/core/src/main/scala/commandcenter/command/ExternalIPCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ExternalIPCommand.scala
@@ -1,7 +1,7 @@
 package commandcenter.command
 
 import commandcenter.CCRuntime.Env
-import commandcenter.util.{ OS, ProcessUtil }
+import commandcenter.util.OS
 import io.circe.Decoder
 import zio.ZIO
 import zio.process.{ Command => PCommand }
@@ -25,7 +25,7 @@ final case class ExternalIPCommand() extends Command[String] {
       List(
         Preview(externalIP)
           .score(Scores.high(input.context))
-          .onRun(ProcessUtil.copyToClipboard(externalIP))
+          .onRun(input.context.ccProcess.setClipboard(externalIP))
       )
     }
 }

--- a/core/src/main/scala/commandcenter/command/HashCommand.scala
+++ b/core/src/main/scala/commandcenter/command/HashCommand.scala
@@ -5,7 +5,6 @@ import com.monovore.decline
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommonOpts._
 import commandcenter.command.util.HashUtil
-import commandcenter.util.ProcessUtil
 import commandcenter.view.DefaultView
 import io.circe.Decoder
 import zio.{ IO, ZIO }
@@ -28,7 +27,7 @@ final case class HashCommand(algorithm: String) extends Command[String] {
       List(
         Preview(hashResult)
           .score(Scores.high(input.context))
-          .onRun(ProcessUtil.copyToClipboard(hashResult))
+          .onRun(searchInput.context.ccProcess.setClipboard(hashResult))
           .render(result => DefaultView(algorithm, result))
       )
     }

--- a/core/src/main/scala/commandcenter/command/LocalIPCommand.scala
+++ b/core/src/main/scala/commandcenter/command/LocalIPCommand.scala
@@ -3,7 +3,6 @@ package commandcenter.command
 import java.net.{ Inet4Address, NetworkInterface }
 
 import commandcenter.CCRuntime.Env
-import commandcenter.util.{ OS, ProcessUtil }
 import commandcenter.view.DefaultView
 import io.circe.Decoder
 import zio.ZIO
@@ -35,7 +34,7 @@ final case class LocalIPCommand() extends Command[String] {
       localIps.map {
         case (interfaceName, localIp) =>
           Preview(localIp)
-            .onRun(ProcessUtil.copyToClipboard(localIp))
+            .onRun(searchInput.context.ccProcess.setClipboard(localIp))
             .score(Scores.high(input.context))
             .view(DefaultView(title, fansi.Str(interfaceName) ++ fansi.Str(": ") ++ fansi.Color.Magenta(localIp)))
       }

--- a/core/src/main/scala/commandcenter/command/LoremIpsumCommand.scala
+++ b/core/src/main/scala/commandcenter/command/LoremIpsumCommand.scala
@@ -5,13 +5,11 @@ import cats.syntax.apply._
 import com.monovore.decline
 import com.monovore.decline.Opts
 import commandcenter.CCRuntime.Env
-import commandcenter.CommandContext
-import commandcenter.util.ProcessUtil
 import commandcenter.view.DefaultView
 import io.circe.Decoder
+import zio._
 
 import scala.io.Source
-import zio._
 
 sealed trait ChunkType
 
@@ -62,7 +60,7 @@ final case class LoremIpsumCommand() extends Command[Unit] {
           case Sentence  => Iterator.continually(lipsum.split("\\.")).flatten.take(i).mkString(". ") ++ "."
           case Paragraph => Iterator.continually(lipsum).take(i).mkString("\n")
         }
-        _ <- ProcessUtil.copyToClipboard(text)
+        _ <- input.context.ccProcess.setClipboard(text)
       } yield ()
       List(
         Preview.unit

--- a/core/src/main/scala/commandcenter/command/RadixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/RadixCommand.scala
@@ -4,10 +4,9 @@ import cats.syntax.apply._
 import com.monovore.decline
 import com.monovore.decline.Opts
 import commandcenter.CCRuntime.Env
-import commandcenter.util.ProcessUtil
 import commandcenter.view.DefaultView
 import io.circe.Decoder
-import zio.{ UIO, ZIO }
+import zio.ZIO
 
 final case class RadixCommand() extends Command[Unit] {
   val commandType: CommandType = CommandType.RadixCommand
@@ -43,7 +42,7 @@ final case class RadixCommand() extends Command[Unit] {
       List(
         Preview.unit
           .score(Scores.high(input.context))
-          .onRun(ProcessUtil.copyToClipboard(message.plainText))
+          .onRun(input.context.ccProcess.setClipboard(message.plainText))
           .view(DefaultView(title, message))
       )
     }

--- a/core/src/main/scala/commandcenter/command/SearchMavenCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SearchMavenCommand.scala
@@ -3,12 +3,11 @@ package commandcenter.command
 import commandcenter.CCRuntime.Env
 import commandcenter.command.CommandError.NotApplicable
 import commandcenter.command.SearchMavenCommand.MavenArtifact
-import commandcenter.util.ProcessUtil
 import commandcenter.view.DefaultView
 import io.circe.{ Decoder, Json }
 import sttp.client._
-import sttp.client.httpclient.zio._
 import sttp.client.circe._
+import sttp.client.httpclient.zio._
 import zio.{ IO, ZIO }
 
 final case class SearchMavenCommand() extends Command[String] {
@@ -40,7 +39,7 @@ final case class SearchMavenCommand() extends Command[String] {
                  } yield {
                    artifacts.map { artifact =>
                      Preview(artifact.toString)
-                       .onRun(ProcessUtil.copyToClipboard(artifact.version))
+                       .onRun(input.context.ccProcess.setClipboard(artifact.version))
                        .score(Scores.high(input.context))
                        .view(
                          DefaultView(

--- a/core/src/main/scala/commandcenter/command/TemperatureCommand.scala
+++ b/core/src/main/scala/commandcenter/command/TemperatureCommand.scala
@@ -41,7 +41,7 @@ final case class TemperatureCommand() extends Command[Double] {
       Preview(temperature)
         .score(Scores.high(searchInput.context))
         .view(DefaultView(title, temperatureFormatted))
-        .onRun(ProcessUtil.copyToClipboard(temperatureFormatted))
+        .onRun(searchInput.context.ccProcess.setClipboard(temperatureFormatted))
     )
 }
 

--- a/core/src/main/scala/commandcenter/command/UUIDCommand.scala
+++ b/core/src/main/scala/commandcenter/command/UUIDCommand.scala
@@ -3,7 +3,6 @@ package commandcenter.command
 import java.util.UUID
 
 import commandcenter.CCRuntime.Env
-import commandcenter.util.ProcessUtil
 import io.circe.Decoder
 import zio.ZIO
 
@@ -19,7 +18,9 @@ final case class UUIDCommand() extends Command[UUID] {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
       uuid  = UUID.randomUUID()
     } yield {
-      List(Preview(uuid).onRun(ProcessUtil.copyToClipboard(uuid.toString)).score(Scores.high(input.context)))
+      List(
+        Preview(uuid).onRun(searchInput.context.ccProcess.setClipboard(uuid.toString)).score(Scores.high(input.context))
+      )
     }
 }
 

--- a/core/src/main/scala/commandcenter/util/JavaVM.scala
+++ b/core/src/main/scala/commandcenter/util/JavaVM.scala
@@ -1,0 +1,5 @@
+package commandcenter.util
+
+object JavaVM {
+  val isSubstrateVM: Boolean = System.getProperty("java.vm.name") == "Substrate VM"
+}

--- a/core/src/main/scala/commandcenter/util/ProcessUtil.scala
+++ b/core/src/main/scala/commandcenter/util/ProcessUtil.scala
@@ -1,20 +1,27 @@
 package commandcenter.util
 
-import java.awt.{ Desktop, Toolkit }
-import java.awt.datatransfer.StringSelection
+import java.awt.Desktop
 import java.net.URI
 
 import zio.RIO
 import zio.blocking.{ Blocking, _ }
+import zio.process.{ Command => PCommand }
 
 object ProcessUtil {
-  def copyToClipboard(s: String): RIO[Blocking, Unit] =
-    effectBlocking {
-      Toolkit.getDefaultToolkit.getSystemClipboard.setContents(new StringSelection(s), null)
-    }
-
   def openBrowser(url: String): RIO[Blocking, Unit] =
-    effectBlocking(
-      Desktop.getDesktop.browse(new URI(url))
-    ) // TODO: Make browser configurable and use Command to open url instead
+    OS.os match {
+      case OS.MacOS =>
+        PCommand("open", url).exitCode.unit
+
+      case OS.Linux =>
+        PCommand("xdg-open", url).exitCode.unit
+
+      case OS.Windows =>
+        PCommand("start", url).exitCode.unit
+
+      case OS.Other =>
+        effectBlocking(
+          Desktop.getDesktop.browse(new URI(url))
+        )
+    }
 }

--- a/core/src/test/scala/commandcenter/CommandSpec.scala
+++ b/core/src/test/scala/commandcenter/CommandSpec.scala
@@ -1,12 +1,14 @@
 package commandcenter
 
+import java.util.Locale
+
 import commandcenter.TestRuntime.TestEnv
 import sttp.client.httpclient.zio.HttpClientZioBackend
+import zio.Layer
 import zio.duration._
 import zio.logging.Logging
 import zio.test.environment.testEnvironment
 import zio.test.{ RunnableSpec, TestAspect, TestExecutor, TestRunner }
-import zio.{ Layer, ZEnv }
 
 trait CommandSpec extends RunnableSpec[TestEnv, Any] {
   val testEnv: Layer[Throwable, TestEnv] =
@@ -15,6 +17,9 @@ trait CommandSpec extends RunnableSpec[TestEnv, Any] {
         ++ Logging.console((_, logEntry) => logEntry)
         ++ HttpClientZioBackend.layer()
     )
+
+  val defaultCommandContext: CommandContext =
+    CommandContext(Locale.ENGLISH, TestTerminal, CCProcess(ProcessHandle.current.pid, None), 1.0)
 
   override def aspects: List[TestAspect[Nothing, TestEnv, Nothing, Any]] =
     List(TestAspect.timeoutWarning(60.seconds))

--- a/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
+++ b/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
@@ -1,6 +1,6 @@
 package commandcenter.command
 
-import commandcenter.{ CommandSpec, TestTerminal }
+import commandcenter.CommandSpec
 import zio.duration._
 import zio.test.Assertion._
 import zio.test._
@@ -12,7 +12,7 @@ object EpochMillisCommandSpec extends CommandSpec {
   def spec =
     suite("EpochMillisCommandSpec")(
       testM("get current time") {
-        val results = Command.search(Vector(command), Map.empty, "epoch", TestTerminal)
+        val results = Command.search(Vector(command), Map.empty, "epoch", defaultCommandContext)
 
         for {
           _        <- TestClock.setTime(5.seconds)
@@ -20,7 +20,7 @@ object EpochMillisCommandSpec extends CommandSpec {
         } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo(5000L))))
       },
       testM("return nothing for non-matching search") {
-        val results = Command.search(Vector(command), Map.empty, "not matching", TestTerminal)
+        val results = Command.search(Vector(command), Map.empty, "not matching", defaultCommandContext)
 
         assertM(results.map(_.previews))(isEmpty)
       }

--- a/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
+++ b/daemon/src/main/scala/commandcenter/daemon/ui/SwingTerminal.scala
@@ -5,10 +5,11 @@ import java.awt.{ BorderLayout, Color, Dimension, Font, GraphicsEnvironment }
 
 import commandcenter.CCRuntime.Env
 import commandcenter.command.{ Command, CommandResult, PreviewResult, SearchResults }
-import commandcenter.ui.{ CCProcess, CCTheme }
+import commandcenter.locale.Language
+import commandcenter.ui.CCTheme
 import commandcenter.util.{ Debounced, OS }
 import commandcenter.view.AnsiRendered
-import commandcenter.{ CCConfig, CCRuntime, CCTerminal, TerminalType }
+import commandcenter._
 import javax.swing._
 import javax.swing.plaf.basic.BasicScrollBarUI
 import javax.swing.text.{ DefaultStyledDocument, StyleConstants, StyleContext }
@@ -99,10 +100,11 @@ final case class SwingTerminal(
 
   inputTextField.addOnChangeListener { e =>
     val searchTerm = inputTextField.getText
+    val context    = CommandContext(Language.detect(searchTerm), SwingTerminal.this, ccProcess, 1.0)
 
     searchDebounce(
       Command
-        .search(config.commands, config.aliases, searchTerm, SwingTerminal.this)
+        .search(config.commands, config.aliases, searchTerm, context)
         .tap(r => commandCursorRef.set(0) *> searchResultsRef.set(r) *> render(r))
         .unit
     ).flatMap(_.join)


### PR DESCRIPTION
Running the cli-client native image you would get the following when trying to access the clipboard or default browser:
`java.lang.IllegalArgumentException: AWT is currently not supported on Substrate VM`

Rather than rely on AWT, I call the equivalent commands manually with zio-process.

With this complete, I think the native executable can now run everything the regular JVM version can. Which is good because the native executable starts up instantaneously.