### PR TITLE
Add better native-image verification

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup GraalVM CE
         uses: rinx/setup-graalvm-ce@v0.0.4
         with:
-          graalvm-version: "20.1.0"
+          graalvm-version: "20.2.0"
           java-version: "java11"
           native-image: "true"
 

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -25,3 +25,4 @@ jobs:
           java -version
           native-image --version
           sbt cli-client/graalvm-native-image:packageBin
+          cli-client/target/graalvm-native-image/cli-client --version


### PR DESCRIPTION
The native-image build is broken again. Since we're currently using unsafe flags like `--allow-incomplete-classpath`, an image can be "successfully" built but fail at runtime.

For added verification, for now I'm just printing the version. This is enough to test creation of the ZIO environment. Eventually we can add something that tests more paths.