### PR TITLE
Decode epoch time support

### DIFF
--- a/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
@@ -1,24 +1,48 @@
 package commandcenter.command
 
+import java.time.{ Instant, ZoneId }
+import java.time.format.{ DateTimeFormatter, FormatStyle }
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.Config
 import commandcenter.CCRuntime.Env
 import commandcenter.tools
-import zio.{ clock, TaskManaged, ZIO, ZManaged }
+import zio.{ clock, Task, TaskManaged, ZIO, ZManaged }
 
-final case class EpochUnixCommand(commandNames: List[String]) extends Command[Long] {
+final case class EpochUnixCommand(commandNames: List[String]) extends Command[String] {
   val commandType: CommandType = CommandType.EpochUnixCommand
   val title: String            = "Epoch (Unix time)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Long]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
     for {
-      input     <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-      epochTime <- clock.currentTime(TimeUnit.SECONDS)
+      input           <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
+      (output, score) <- if (input.rest.trim.isEmpty) {
+                           (clock.currentTime(TimeUnit.SECONDS).map(time => (time.toString, Scores.high)))
+                         } else {
+                           input.rest.toLongOption match {
+                             case Some(seconds) =>
+                               Task {
+                                 val formatted = Instant
+                                   .ofEpochSecond(seconds)
+                                   .atZone(ZoneId.systemDefault())
+                                   .format(DateTimeFormatter.ofLocalizedDateTime(FormatStyle.MEDIUM))
+
+                                 val score = if (seconds < 100000000000L) {
+                                   Scores.high(input.context)
+                                 } else {
+                                   Scores.high(input.context) * 0.9
+                                 }
+
+                                 (formatted, score)
+                               }.mapError(CommandError.UnexpectedException)
+
+                             case None => ZIO.fail(CommandError.NotApplicable)
+                           }
+                         }
     } yield List(
-      Preview(epochTime)
-        .score(Scores.high(input.context))
-        .onRun(tools.setClipboard(epochTime.toString))
+      Preview(output)
+        .score(score)
+        .onRun(tools.setClipboard(output))
     )
 }
 

--- a/core/src/main/scala/commandcenter/command/SnippetsCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SnippetsCommand.scala
@@ -24,7 +24,7 @@ final case class SnippetsCommand(commandNames: List[String], snippets: List[Snip
           Scores.high(searchInput.context)
         else {
           // TODO: Implement better scoring algorithm (like Sublime Text fuzzy search)
-          val matchScore = LengthScorer.score(snip.keyword, snippetSearch)
+          val matchScore = LengthScorer.scoreDefault(snip.keyword, snippetSearch)
           Scores.high(searchInput.context) * matchScore
         }
 

--- a/core/src/main/scala/commandcenter/scorers/LengthScorer.scala
+++ b/core/src/main/scala/commandcenter/scorers/LengthScorer.scala
@@ -1,11 +1,17 @@
 package commandcenter.scorers
 
 object LengthScorer {
-  def score(target: String, input: String): Double =
+  def scoreDefault(target: String, input: String): Double =
     if (target.startsWith(input))
       1.0 - (target.length - input.length) / target.length.toDouble
     else if (target.contains(input))
       (1.0 - (target.length - input.length) / target.length.toDouble) * 0.5
+    else
+      0.0
+
+  def scorePrefix(target: String, input: String): Double =
+    if (target.startsWith(input))
+      1.0 - (target.length - input.length) / target.length.toDouble
     else
       0.0
 }

--- a/core/src/test/scala/commandcenter/SearchSpec.scala
+++ b/core/src/test/scala/commandcenter/SearchSpec.scala
@@ -29,7 +29,7 @@ object SearchSpec extends CommandBaseSpec {
         for {
           _        <- TestClock.setTime(1.second)
           previews <- results.map(_.previews)
-        } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo(1000L.asInstanceOf[AnyVal]))))
+        } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo("1000".asInstanceOf[Any]))))
       }
     )
 }

--- a/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
+++ b/core/src/test/scala/commandcenter/command/EpochMillisCommandSpec.scala
@@ -12,12 +12,12 @@ object EpochMillisCommandSpec extends CommandBaseSpec {
   def spec =
     suite("EpochMillisCommandSpec")(
       testM("get current time") {
-        val results = Command.search(Vector(command), Map.empty, "epoch", defaultCommandContext)
+        val results = Command.search(Vector(command), Map.empty, "epochmillis", defaultCommandContext)
 
         for {
           _        <- TestClock.setTime(5.seconds)
           previews <- results.map(_.previews)
-        } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo(5000L))))
+        } yield assert(previews)(hasFirst(hasField("result", _.result, equalTo("5000".asInstanceOf[Any]))))
       },
       testM("return nothing for non-matching search") {
         val results = Command.search(Vector(command), Map.empty, "not matching", defaultCommandContext)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0
+sbt.version=1.3.13


### PR DESCRIPTION
This allows typing `epoch 1602424979` and it'll show you a human readable date/time for it.

Epoch millis vs. epoch seconds will be scored differently based on which is more "likely" (if the Long is very large, epoch millis will be favored).