### PR TITLE
Add headless mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val root = project
          ||     ,-. ,-,-. ,-,-. ,-. ,-. ,-|   |     ,-. ,-. |- ,-. ,-.
          ||     | | | | | | | | ,-| | | | |   |     |-' | | |  |-' |
          |`---' `-' ' ' ' ' ' ' `-^ ' ' `-'   `---' `-' ' ' `' `-' '
+         |
          |""".stripMargin,
     usefulTasks := Seq(
       UsefulTask("a", "~compile", "Compile all modules with file-watch enabled"),
@@ -73,9 +74,14 @@ lazy val coreUI = module("core-ui")
 lazy val cliClient = module("cli-client")
   .dependsOn(coreUI)
   .settings(
+    fork := true,
+    baseDirectory in run := file("."),
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "svm-subs" % Version.graal,
+      "org.zeromq"     % "jeromq"   % "0.5.2"
+    ),
     // Windows native terminal requires JNA.
     libraryDependencies ++= Seq("net.java.dev.jna" % "jna-platform" % "5.6.0").filter(_ => OS.os == OS.Windows),
-    libraryDependencies ++= Seq("org.scalameta" %% "svm-subs" % Version.graal),
     mainClass in assembly := Some("commandcenter.cli.Main"),
     assemblyJarName in assembly := "ccc.jar",
     assemblyMergeStrategy in assembly := {
@@ -88,6 +94,7 @@ lazy val cliClient = module("cli-client")
       "-H:+TraceClassInitialization",
       "-H:IncludeResources=lipsum",
       "-H:IncludeResources=applescript/.*",
+      "--rerun-class-initialization-at-runtime=sun.security.provider.NativePRNG", // TODO: This is deprecated and doesn't quite work. Will need a workaround.
       "--initialize-at-run-time=com.googlecode.lanterna.terminal.win32.WindowsTerminal",
       "--initialize-at-build-time",
       "--no-fallback",

--- a/cli-client/src/main/scala/commandcenter/cli/CliArgs.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/CliArgs.scala
@@ -1,0 +1,18 @@
+package commandcenter.cli
+
+import com.monovore.decline
+import com.monovore.decline.{ Command, Opts }
+
+object CliArgs {
+  val headlessCommand =
+    decline.Command("headless", "Run in headless mode waiting to receive requests")(Opts(CliCommand.Headless))
+  val versionCommand  = decline.Command("version", "Print the current version")(Opts(CliCommand.Version))
+  val helpCommand     = decline.Command("help", "Display usage help")(Opts(CliCommand.Help))
+
+  val opts: Opts[CliCommand] =
+    Opts.subcommand(headlessCommand) orElse
+      Opts.subcommand(versionCommand) orElse
+      Opts.subcommand(helpCommand) withDefault CliCommand.Standalone
+
+  val rootCommand: Command[CliCommand] = decline.Command("commandcenter", "Command Center commands")(opts)
+}

--- a/cli-client/src/main/scala/commandcenter/cli/CliCommand.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/CliCommand.scala
@@ -1,0 +1,10 @@
+package commandcenter.cli
+
+sealed trait CliCommand
+
+object CliCommand {
+  case object Standalone extends CliCommand
+  case object Headless   extends CliCommand
+  case object Help       extends CliCommand
+  case object Version    extends CliCommand
+}

--- a/cli-client/src/main/scala/commandcenter/cli/Main.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/Main.scala
@@ -2,20 +2,22 @@ package commandcenter.cli
 
 import com.googlecode.lanterna.input.{ KeyStroke, KeyType }
 import commandcenter.CCRuntime.Env
+import commandcenter._
+import commandcenter.cli.message.{ CCRequest, CCResponse }
+import commandcenter.cli.zmq.{ ZPublisher, ZSubscriber }
 import commandcenter.command._
 import commandcenter.shortcuts.Shortcuts
 import commandcenter.ui.{ CliTerminal, EventResult }
-import commandcenter.{ CCApp, CCConfig, TerminalType }
+import io.circe.syntax._
+import org.zeromq.{ SocketType, ZMQ }
 import zio._
 import zio.console._
+import zio.logging.log
 import zio.stream.ZStream
 
 object Main extends CCApp {
   val terminalType: TerminalType        = TerminalType.Cli
   val shortcutsLayer: ULayer[Shortcuts] = Shortcuts.unsupported
-
-  def printVersion: URManaged[Console, ExitCode] =
-    putStrLn(s"Command Center CLI v${commandcenter.BuildInfo.version}").exitCode.toManaged_
 
   def uiLoop: RManaged[Env, ExitCode] =
     for {
@@ -45,13 +47,64 @@ object Main extends CCApp {
                   } yield ()).exitCode.toManaged_
     } yield exitCode
 
-  def run(args: List[String]): URIO[Env, ExitCode] = {
-    // TODO: Add proper parsing with Decline. Add `--help`, `--version`, `--numeric-version`, etc.
-    val main = if (args.isEmpty) uiLoop else printVersion
+  def headlessLoop: RManaged[Env, Unit] =
+    for {
+      config    <- CCConfig.load
+      terminal  <- HeadlessTerminal.create
+      zmqContext = ZMQ.context(1)
+      pub        = ZPublisher(zmqContext.socket(SocketType.PUB))
+      sub        = ZSubscriber(zmqContext.socket(SocketType.SUB))
+      subAddress = "tcp://*:9980" // TODO: Make ports configurable. Also accept `ipc://port` format and so on
+      _         <- pub.bind("tcp://*:9981")
+      _         <- sub.connect(subAddress)
+      _         <- sub.subscribeAll.toManaged_
+      _         <- putStrLn(s"Waiting for requests at $subAddress").toManaged_
+      _         <-
+        (for {
+          rawMessage           <- sub.receiveString
+          message               = io.circe.parser.parse(rawMessage).flatMap(_.as[CCRequest])
+          (jsonResponse, cont) <- message match {
+                                    case Right(CCRequest.Search(term, _)) =>
+                                      for {
+                                        results <- terminal.search(config.commands, config.aliases)(term)
+                                        response = CCResponse.Search.fromSearchResults(results)
+                                      } yield (response.asJson, true)
 
-    main.useNow.catchAll { t =>
-      t.printStackTrace()
-      UIO(ExitCode.failure)
-    }
-  }
+                                    case Right(CCRequest.Run(index, _)) =>
+                                      for {
+                                        result <- terminal.run(index)
+                                      } yield (CCResponse.Run(result.isDefined).asJson, true)
+
+                                    case Right(CCRequest.Exit(_)) => UIO((CCResponse.Exit.asJson, false))
+
+                                    case Left(error) =>
+                                      for {
+                                        _ <- log.throwable("Received an invalid request", error)
+                                      } yield (CCResponse.Error(s"Invalid request: ${error.getMessage}").asJson, true)
+                                  }
+          _                    <- pub.send(jsonResponse.noSpaces)
+        } yield cont).repeatWhile(identity).toManaged_
+    } yield ()
+
+  def run(args: List[String]): URIO[Env, ExitCode] =
+    CliArgs.rootCommand
+      .parse(args)
+      .fold(
+        help => putStrLn(help.toString),
+        {
+          case CliCommand.Headless =>
+            headlessLoop.useNow
+
+          case CliCommand.Standalone =>
+            uiLoop.useNow.tapError { t =>
+              UIO(t.printStackTrace())
+            }
+
+          case CliCommand.Help =>
+            putStrLn(CliArgs.rootCommand.showHelp)
+
+          case CliCommand.Version => putStrLn(s"Command Center CLI v${commandcenter.BuildInfo.version}")
+        }
+      )
+      .exitCode
 }

--- a/cli-client/src/main/scala/commandcenter/cli/message/CCRequest.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/message/CCRequest.scala
@@ -1,0 +1,43 @@
+package commandcenter.cli.message
+
+import commandcenter.codec.Codecs
+import io.circe._
+
+sealed trait CCRequest {
+  def correlationId: Option[String]
+}
+
+object CCRequest {
+  final case class Search(term: String, correlationId: Option[String]) extends CCRequest
+
+  object Search {
+    implicit val decoder: Decoder[Search] = Decoder.forProduct2("term", "correlationId")(Search.apply)
+    implicit val encoder: Encoder[Search] = Encoder.forProduct2("term", "correlationId")(s => (s.term, s.correlationId))
+  }
+
+  final case class Run(index: Int, correlationId: Option[String]) extends CCRequest
+
+  object Run {
+    implicit val decoder: Decoder[Run] = Decoder.forProduct2("index", "correlationId")(Run.apply)
+    implicit val encoder: Encoder[Run] = Encoder.forProduct2("index", "correlationId")(s => (s.index, s.correlationId))
+  }
+
+  final case class Exit(correlationId: Option[String]) extends CCRequest
+
+  object Exit {
+    implicit val decoder: Decoder[Exit] = Decoder.forProduct1("correlationId")(Exit.apply)
+    implicit val encoder: Encoder[Exit] = Encoder.forProduct1("correlationId")(s => s.correlationId)
+  }
+
+  implicit val decoder: Decoder[CCRequest] = Codecs.decodeSumBySoleKey {
+    case ("search", c) => c.as[Search]
+    case ("run", c)    => c.as[Run]
+    case ("exit", c)   => c.as[Exit]
+  }
+
+  implicit val encoder: Encoder[CCRequest] = Encoder.instance {
+    case a: Search => Search.encoder(a)
+    case a: Run    => Run.encoder(a)
+    case a: Exit   => Exit.encoder(a)
+  }
+}

--- a/cli-client/src/main/scala/commandcenter/cli/message/CCResponse.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/message/CCResponse.scala
@@ -1,0 +1,56 @@
+package commandcenter.cli.message
+
+import commandcenter.command.SearchResults
+import commandcenter.view.Rendered
+import io.circe._
+
+sealed trait CCResponse
+
+object CCResponse {
+  final case class Search(searchTerm: String, results: Vector[SearchResult]) extends CCResponse
+
+  object Search {
+    implicit val encoder: Encoder[Search] = Encoder.forProduct2("searchTerm", "results")(s => (s.searchTerm, s.results))
+
+    def fromSearchResults[A](results: SearchResults[A]): Search =
+      Search(
+        results.searchTerm,
+        results.previews.map { r =>
+          r.renderFn() match {
+            case ansi: Rendered.Ansi => Some(SearchResult(r.source.title, ansi, r.score))
+            case _: Rendered.Styled  => None
+          }
+        }.collect { case Some(r) => r }
+      )
+  }
+
+  final case class SearchResult(title: String, rendered: Rendered.Ansi, score: Double)
+
+  object SearchResult {
+    implicit val encoder: Encoder[SearchResult] =
+      Encoder.forProduct3("title", "rendered", "score")(s => (s.title, s.rendered.ansiStr.render, s.score))
+  }
+
+  final case class Run(success: Boolean) extends CCResponse
+
+  object Run {
+    implicit val encoder: Encoder[Run] = Encoder.forProduct1("success")(s => s.success)
+  }
+
+  case object Exit extends CCResponse {
+    implicit val encoder: Encoder[Exit.type] = Encoder.encodeUnit.contramap(_ => ())
+  }
+
+  final case class Error(message: String) extends CCResponse
+
+  object Error {
+    implicit val encoder: Encoder[Error] = Encoder.forProduct1("message")(s => s.message)
+  }
+
+  implicit val encoder: Encoder[CCResponse] = Encoder.instance {
+    case a: Search    => Search.encoder(a)
+    case a: Run       => Run.encoder(a)
+    case a: Exit.type => Exit.encoder(a)
+    case a: Error     => Error.encoder(a)
+  }
+}

--- a/cli-client/src/main/scala/commandcenter/cli/zmq/ZPublisher.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/zmq/ZPublisher.scala
@@ -1,0 +1,12 @@
+package commandcenter.cli.zmq
+
+import org.zeromq.ZMQ
+import zio.{ Task, TaskManaged, ZManaged }
+
+final case class ZPublisher(socket: ZMQ.Socket) {
+  def bind(address: String): TaskManaged[ZMQ.Socket] =
+    ZManaged.fromAutoCloseable(Task(socket.bind(address)).as(socket))
+
+  def send(s: String): Task[Boolean] =
+    Task(socket.send(s))
+}

--- a/cli-client/src/main/scala/commandcenter/cli/zmq/ZSubscriber.scala
+++ b/cli-client/src/main/scala/commandcenter/cli/zmq/ZSubscriber.scala
@@ -1,0 +1,16 @@
+package commandcenter.cli.zmq
+
+import org.zeromq.ZMQ
+import zio.{ RIO, Task, TaskManaged, ZManaged }
+import zio.blocking.{ effectBlocking, Blocking }
+
+final case class ZSubscriber(socket: ZMQ.Socket) {
+  def connect(address: String): TaskManaged[ZMQ.Socket] =
+    ZManaged.fromAutoCloseable(Task(socket.connect(address)).as(socket))
+
+  def subscribeAll: Task[Boolean] =
+    Task(socket.subscribe(Array.emptyByteArray))
+
+  def receiveString: RIO[Blocking, String] =
+    effectBlocking(socket.recvStr())
+}

--- a/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
+++ b/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
@@ -271,8 +271,6 @@ final case class CliTerminal[T <: Terminal](
 }
 
 object CliTerminal {
-//  val server = new TelnetTerminalServer(23, StandardCharsets.UTF_8) // Need to have one instance of this and clean it up at the end so we don't get "address in use"
-
   def createNative(config: CCConfig): Managed[Throwable, CliTerminal[Terminal]] =
     create(config) {
       val terminalFactory = new DefaultTerminalFactory()

--- a/core/src/main/scala/commandcenter/HeadlessTerminal.scala
+++ b/core/src/main/scala/commandcenter/HeadlessTerminal.scala
@@ -1,0 +1,51 @@
+package commandcenter
+
+import java.awt.Dimension
+
+import commandcenter.CCRuntime.Env
+import commandcenter.command.{ Command, PreviewResult, SearchResults }
+import commandcenter.locale.Language
+import zio._
+
+case class HeadlessTerminal(searchResultsRef: Ref[SearchResults[Any]]) extends CCTerminal {
+  def terminalType: TerminalType = TerminalType.Test
+
+  def opacity: RIO[Env, Float] = UIO(1.0f)
+
+  def setOpacity(opacity: Float): RIO[Env, Unit] = ZIO.unit
+
+  def size: RIO[Env, Dimension] = UIO(new Dimension(80, 40))
+
+  def setSize(width: Int, height: Int): RIO[Env, Unit] = ZIO.unit
+
+  def reload: RIO[Env, Unit] = ZIO.unit
+
+  def search(commands: Vector[Command[Any]], aliases: Map[String, List[String]])(
+    searchTerm: String
+  ): URIO[Env, SearchResults[Any]] = {
+    val context = CommandContext(Language.detect(searchTerm), this, 1.0)
+
+    Command
+      .search(commands, aliases, searchTerm, context)
+      .tap { r =>
+        searchResultsRef.set(r)
+      }
+  }
+
+  def run(cursorIndex: Int): URIO[Env, Option[PreviewResult[Any]]] =
+    for {
+      results      <- searchResultsRef.get
+      previewResult = results.previews.lift(cursorIndex)
+      _            <- ZIO.foreach_(previewResult) { preview =>
+                        // TODO: Log defects
+                        preview.onRun.absorb.forkDaemon
+                      }
+    } yield previewResult
+}
+
+object HeadlessTerminal {
+  def create: UManaged[HeadlessTerminal] =
+    for {
+      searchResultsRef <- Ref.makeManaged(SearchResults.empty[Any])
+    } yield HeadlessTerminal(searchResultsRef)
+}


### PR DESCRIPTION
Uses ZeroMQ to support running Command Center in headless mode. Meaning it's now possible to run it as a server and send/receive requests/responses through TCP/IPC/etc.

This makes supporting multiple frontends possible. Even in other languages.