### PR TITLE
Add window management actions

### DIFF
--- a/application.conf
+++ b/application.conf
@@ -4,6 +4,18 @@ keyboard: {
   openShortcut_MacOS: "meta SPACE"
 }
 
+globalActions: [
+  # Note: Window actions currently only supported for Windows
+//  { id: "centerWindow", shortcut: "meta alt C" }
+//  { id: "moveToPreviousDisplay", shortcut: "control meta alt UP" }
+//  { id: "moveToNextDisplay", shortcut: "control meta alt DOWN" }
+//  { id: "resizeToScreenSize", shortcut: "meta alt A" }
+//  { id: "cycleWindowSizeLeft", shortcut: "meta alt LEFT" }
+//  { id: "cycleWindowSizeRight", shortcut: "meta alt RIGHT" }
+//  { id: "cycleWindowSizeTop", shortcut: "meta alt UP" }
+//  { id: "cycleWindowSizeBottom", shortcut: "meta alt DOWN" }
+]
+
 display: {
   width: 1600
   maxHeight: 500
@@ -15,7 +27,7 @@ display: {
   ]
 }
 
-commands = [
+commands: [
   {type: "HashCommand", algorithm: "MD5"}
   {type: "HashCommand", algorithm: "SHA-1"}
   {type: "HashCommand", algorithm: "SHA-256"}

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,8 @@ lazy val core = module("core")
       "io.circe"                     %% "circe-parser"           % Version.circe,
       "com.monovore"                 %% "decline"                % "1.3.0",
       "com.lihaoyi"                  %% "fansi"                  % "0.2.9",
-      "com.beachape"                 %% "enumeratum"             % "1.6.1",
+      "com.beachape"                 %% "enumeratum"             % Version.enumeratum,
+      "com.beachape"                 %% "enumeratum-circe"       % Version.enumeratum,
       "com.softwaremill.sttp.client" %% "core"                   % Version.sttp,
       "com.softwaremill.sttp.client" %% "circe"                  % Version.sttp,
       "com.softwaremill.sttp.client" %% "httpclient-backend-zio" % Version.sttp,
@@ -133,8 +134,10 @@ lazy val emulatorCore = module("emulator-core")
     fork := true,
     baseDirectory in run := file("."),
     libraryDependencies ++= Seq(
-      "com.github.tulskiy" % "jkeymaster" % "1.3",
-      "org.slf4j"          % "slf4j-nop"  % "1.7.30" // Seems to be required for jkeymaster on Linux
+      "com.github.tulskiy" % "jkeymaster"   % "1.3",
+      "net.java.dev.jna"   % "jna"          % "5.6.0",
+      "net.java.dev.jna"   % "jna-platform" % "5.6.0",
+      "org.slf4j"          % "slf4j-nop"    % "1.7.30" // Seems to be required for jkeymaster on Linux
     )
   )
 

--- a/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
+++ b/core-ui/src/main/scala/commandcenter/ui/CliTerminal.scala
@@ -294,7 +294,7 @@ object CliTerminal {
       textCursorRef      <- Ref.makeManaged(TextCursor.unit)
       searchResultsRef   <- Ref.makeManaged(SearchResults.empty[Any])
       keyHandlersRef     <- Ref.makeManaged(Map.empty[KeyStroke, URIO[Env, EventResult]])
-      searchDebounce     <- Debounced[Env, Nothing, Unit](250.millis).toManaged_
+      searchDebounce     <- Debounced[Env, Nothing, Unit](200.millis).toManaged_
       renderQueue        <- Queue.sliding[SearchResults[Any]](1).toManaged_
       lastSearchFiberRef <- Ref.makeManaged(Option.empty[Fiber[Throwable, SearchResults[Any]]])
     } yield CliTerminal(

--- a/core/src/main/scala/commandcenter/CCConfig.scala
+++ b/core/src/main/scala/commandcenter/CCConfig.scala
@@ -1,8 +1,5 @@
 package commandcenter
 
-import java.awt.Font
-import java.io.File
-
 import com.typesafe.config.{ Config, ConfigFactory }
 import commandcenter.CCRuntime.Env
 import commandcenter.command.{ Command, CommandPlugin }
@@ -10,10 +7,14 @@ import commandcenter.config.ConfigParserExtensions._
 import commandcenter.config.Decoders._
 import commandcenter.event.KeyboardShortcut
 import commandcenter.util.OS
+import enumeratum.EnumEntry.LowerCamelcase
+import enumeratum.{ CirceEnum, Enum, EnumEntry }
 import io.circe.Decoder
 import zio.blocking._
 import zio.{ RManaged, ZManaged }
 
+import java.awt.Font
+import java.io.File
 import scala.util.Try
 
 object CCConfig {
@@ -34,7 +35,8 @@ object CCConfig {
       aliases        <- ZManaged.fromEither(config.as[Map[String, List[String]]]("aliases"))
       displayConfig  <- ZManaged.fromEither(config.as[DisplayConfig]("display"))
       keyboardConfig <- ZManaged.fromEither(config.as[KeyboardConfig]("keyboard"))
-    } yield CCConfig(commands.toVector, aliases, displayConfig, keyboardConfig)
+      globalActions  <- ZManaged.fromEither(config.get[Vector[GlobalAction]]("globalActions"))
+    } yield CCConfig(commands.toVector, aliases, displayConfig, keyboardConfig, globalActions)
 
   private def envConfigFile: Option[File] =
     sys.env
@@ -55,7 +57,8 @@ final case class CCConfig(
   commands: Vector[Command[Any]],
   aliases: Map[String, List[String]],
   display: DisplayConfig,
-  keyboard: KeyboardConfig
+  keyboard: KeyboardConfig,
+  globalActions: Vector[GlobalAction]
 )
 
 final case class DisplayConfig(width: Int, maxHeight: Int, opacity: Float, fonts: List[Font])
@@ -75,4 +78,27 @@ object KeyboardConfig {
       suspendShortcut <- c.get[Option[String]]("suspendShortcut")
     } yield KeyboardConfig(openShortcut, suspendShortcut)
   }
+}
+
+// TODO: Make this an ADT with special configs for each case
+final case class GlobalAction(id: GlobalActionId, shortcut: KeyboardShortcut)
+
+object GlobalAction {
+  implicit val decoder: Decoder[GlobalAction] =
+    Decoder.forProduct2("id", "shortcut")(GlobalAction.apply)
+}
+
+sealed trait GlobalActionId extends EnumEntry with LowerCamelcase
+
+object GlobalActionId extends Enum[GlobalActionId] with CirceEnum[GlobalActionId] {
+  case object CenterWindow          extends GlobalActionId
+  case object MoveToNextDisplay     extends GlobalActionId
+  case object MoveToPreviousDisplay extends GlobalActionId
+  case object ResizeToScreenSize    extends GlobalActionId
+  case object CycleWindowSizeLeft   extends GlobalActionId
+  case object CycleWindowSizeRight  extends GlobalActionId
+  case object CycleWindowSizeTop    extends GlobalActionId
+  case object CycleWindowSizeBottom extends GlobalActionId
+
+  lazy val values: IndexedSeq[GlobalActionId] = findValues
 }

--- a/emulator-core/src/main/scala/commandcenter/GlobalActions.scala
+++ b/emulator-core/src/main/scala/commandcenter/GlobalActions.scala
@@ -1,0 +1,65 @@
+package commandcenter
+
+import commandcenter.shortcuts.Shortcuts
+import zio.{ RIO, ZIO }
+
+object GlobalActions {
+  def setupCommon(actions: Vector[GlobalAction]): RIO[Shortcuts, Unit] =
+    ZIO.foreach_(actions) { action =>
+      val run = action.id match {
+        case GlobalActionId.CenterWindow =>
+          WindowManager.centerScreen
+
+        case GlobalActionId.MoveToPreviousDisplay =>
+          WindowManager.moveToPreviousDisplay
+
+        case GlobalActionId.MoveToNextDisplay =>
+          WindowManager.moveToNextDisplay
+
+        case GlobalActionId.ResizeToScreenSize =>
+          WindowManager.resizeToScreenSize
+
+        case id @ GlobalActionId.CycleWindowSizeLeft =>
+          WindowManager
+            .cycleWindowSize(1, id.entryName)(
+              Vector(
+                WindowBounds(left = 0, top = 0, right = 0.5, bottom = 1.0),
+                WindowBounds(left = 0 / 3.0, top = 0, right = 2.0 / 3.0, bottom = 1.0),
+                WindowBounds(left = 0 / 3.0, top = 0, right = 1.0 / 3.0, bottom = 1.0)
+              )
+            )
+
+        case id @ GlobalActionId.CycleWindowSizeRight =>
+          WindowManager
+            .cycleWindowSize(1, id.entryName)(
+              Vector(
+                WindowBounds(left = 0.5, top = 0, right = 1.0, bottom = 1.0),
+                WindowBounds(left = 1.0 / 3.0, top = 0, right = 1.0, bottom = 1.0),
+                WindowBounds(left = 2.0 / 3.0, top = 0, right = 1.0, bottom = 1.0)
+              )
+            )
+
+        case id @ GlobalActionId.CycleWindowSizeTop =>
+          WindowManager
+            .cycleWindowSize(1, id.entryName)(
+              Vector(
+                WindowBounds(left = 0, top = 0, right = 1.0, bottom = 0.5),
+                WindowBounds(left = 0, top = 0, right = 1.0, bottom = 2.0 / 3.0),
+                WindowBounds(left = 0, top = 0, right = 1.0, bottom = 1.0 / 3.0)
+              )
+            )
+
+        case id @ GlobalActionId.CycleWindowSizeBottom =>
+          WindowManager
+            .cycleWindowSize(1, id.entryName)(
+              Vector(
+                WindowBounds(left = 0, top = 0.5, right = 1.0, bottom = 1.0),
+                WindowBounds(left = 0, top = 1.0 / 3.0, right = 1.0, bottom = 1.0),
+                WindowBounds(left = 0, top = 2.0 / 3.0, right = 1.0, bottom = 1.0)
+              )
+            )
+      }
+
+      shortcuts.addGlobalShortcut(action.shortcut)(_ => run.ignore)
+    }
+}

--- a/emulator-core/src/main/scala/commandcenter/WindowManager.scala
+++ b/emulator-core/src/main/scala/commandcenter/WindowManager.scala
@@ -1,0 +1,192 @@
+package commandcenter
+
+import com.sun.jna.platform.win32.WinDef.{ HDC, LPARAM, RECT }
+import com.sun.jna.platform.win32.WinUser.{ MONITORENUMPROC, MONITORINFO, MONITORINFOEX }
+import com.sun.jna.platform.win32.{ User32, WinUser }
+import commandcenter.command.cache.InMemoryCache
+import zio.clock.Clock
+import zio.{ RIO, Task }
+
+import java.util
+import scala.collection.mutable
+
+object WindowManager {
+  def centerScreen: Task[Unit] = Task {
+    val window  = User32.INSTANCE.GetForegroundWindow()
+    val monitor = User32.INSTANCE.MonitorFromWindow(window, WinUser.MONITOR_DEFAULTTONEAREST)
+
+    val monitorInfo = new MONITORINFO()
+    User32.INSTANCE.GetMonitorInfo(monitor, monitorInfo)
+
+    val windowRect = new RECT()
+    User32.INSTANCE.GetWindowRect(window, windowRect)
+
+    val windowWidth  = windowRect.right - windowRect.left
+    val windowHeight = windowRect.bottom - windowRect.top
+
+    val monitorWidth  = monitorInfo.rcWork.right - monitorInfo.rcWork.left
+    val monitorHeight = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top
+
+    val x = monitorInfo.rcWork.left + (monitorWidth - windowWidth) / 2
+    val y = monitorInfo.rcWork.top + (monitorHeight - windowHeight) / 2
+
+    User32.INSTANCE.SetWindowPos(window, null, x, y, windowWidth, windowHeight, WinUser.SWP_NOZORDER)
+  }
+
+  def resizeToScreenSize: Task[Unit] = Task {
+    val window  = User32.INSTANCE.GetForegroundWindow()
+    val monitor = User32.INSTANCE.MonitorFromWindow(window, WinUser.MONITOR_DEFAULTTONEAREST)
+
+    val monitorInfo = new MONITORINFO()
+    User32.INSTANCE.GetMonitorInfo(monitor, monitorInfo)
+
+    val windowRect = new RECT()
+    User32.INSTANCE.GetWindowRect(window, windowRect)
+
+    val monitorWidth  = monitorInfo.rcWork.right - monitorInfo.rcWork.left
+    val monitorHeight = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top
+
+    val x = monitorInfo.rcWork.left
+    val y = monitorInfo.rcWork.top
+
+    User32.INSTANCE.SetWindowPos(window, null, x, y, monitorWidth, monitorHeight, WinUser.SWP_NOZORDER)
+  }
+
+  def cycleWindowSize(step: Int, name: String)(
+    boundsList: Vector[WindowBounds]
+  ): RIO[InMemoryCache with Clock, Unit] = {
+    val cacheKey = "cycleWindowState"
+    for {
+      cycleWindowState <- InMemoryCache.get[CycleWindowState](cacheKey).map(_.getOrElse(CycleWindowState(-step, None)))
+      newIndex          = if (cycleWindowState.lastAction.contains(name)) {
+                            if (step > 0) {
+                              (cycleWindowState.index + step) % boundsList.length
+                            } else {
+                              (boundsList.length - cycleWindowState.index - step) % boundsList.length
+                            }
+                          } else {
+                            0
+                          }
+      _                <- transform(boundsList(newIndex))
+      _                <- InMemoryCache.set(cacheKey, CycleWindowState(newIndex, Some(name)))
+    } yield ()
+  }
+
+  def transform(bounds: WindowBounds): Task[Unit] = Task {
+    val window  = User32.INSTANCE.GetForegroundWindow()
+    val monitor = User32.INSTANCE.MonitorFromWindow(window, WinUser.MONITOR_DEFAULTTONEAREST)
+
+    val monitorInfo = new MONITORINFO()
+    User32.INSTANCE.GetMonitorInfo(monitor, monitorInfo)
+
+    val windowRect = new RECT()
+    User32.INSTANCE.GetWindowRect(window, windowRect)
+
+    val monitorWidth  = monitorInfo.rcWork.right - monitorInfo.rcWork.left
+    val monitorHeight = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top
+
+    val newWindowWidth  = monitorWidth * (bounds.right - bounds.left)
+    val newWindowHeight = monitorHeight * (bounds.bottom - bounds.top)
+
+    val x = monitorInfo.rcWork.left + bounds.left * monitorWidth
+    val y = monitorInfo.rcWork.top + bounds.top * monitorHeight
+
+    User32.INSTANCE.SetWindowPos(
+      window,
+      null,
+      x.round.toInt,
+      y.round.toInt,
+      newWindowWidth.round.toInt,
+      newWindowHeight.round.toInt,
+      WinUser.SWP_NOZORDER
+    )
+  }
+
+  def moveToNextDisplay: Task[Unit] = moveToDisplay(1)
+
+  def moveToPreviousDisplay: Task[Unit] = moveToDisplay(-1)
+
+  def moveToDisplay(step: Int): Task[Unit] = Task {
+    val window  = User32.INSTANCE.GetForegroundWindow()
+    val monitor = User32.INSTANCE.MonitorFromWindow(window, WinUser.MONITOR_DEFAULTTONEAREST)
+
+    val windowRect = new RECT()
+    User32.INSTANCE.GetWindowRect(window, windowRect)
+
+    val currentMonitor = new MONITORINFOEX()
+    User32.INSTANCE.GetMonitorInfo(monitor, currentMonitor)
+
+    val monitors = new mutable.ArrayDeque[MONITORINFOEX]()
+
+    User32.INSTANCE.EnumDisplayMonitors(
+      null,
+      null,
+      new MONITORENUMPROC() {
+        override def apply(hMonitor: WinUser.HMONITOR, hdcMonitor: HDC, lprcMonitor: RECT, dwData: LPARAM): Int = {
+          val monitorInfo = new MONITORINFOEX()
+          User32.INSTANCE.GetMonitorInfo(hMonitor, monitorInfo)
+          monitors.append(monitorInfo)
+          1
+        }
+      },
+      new LPARAM(0)
+    )
+
+    val currentMonitorIndex = monitors.indexWhere(x => util.Arrays.equals(x.szDevice, currentMonitor.szDevice))
+
+    val nextMonitorIndex = if (step > 0) {
+      (currentMonitorIndex + step) % monitors.length
+    } else {
+      (monitors.length - currentMonitorIndex - step) % monitors.length
+    }
+
+    val nextMonitor = monitors(nextMonitorIndex)
+
+    val currentMonitorWidth  = currentMonitor.rcWork.right - currentMonitor.rcWork.left
+    val currentMonitorHeight = currentMonitor.rcWork.bottom - currentMonitor.rcWork.top
+
+    val boundsLeft   = (windowRect.left - currentMonitor.rcWork.left) / currentMonitorWidth.toDouble
+    val boundsRight  = (windowRect.right - currentMonitor.rcWork.left) / currentMonitorWidth.toDouble
+    val boundsBottom = (windowRect.bottom - currentMonitor.rcWork.top) / currentMonitorHeight.toDouble
+    val boundsTop    = (windowRect.top - currentMonitor.rcWork.top) / currentMonitorHeight.toDouble
+
+    val nextMonitorWidth  = nextMonitor.rcWork.right - nextMonitor.rcWork.left
+    val nextMonitorHeight = nextMonitor.rcWork.bottom - nextMonitor.rcWork.top
+
+    val x               = nextMonitor.rcWork.left + boundsLeft * nextMonitorWidth
+    val y               = nextMonitor.rcWork.top + boundsTop * nextMonitorHeight
+    val newWindowWidth  = (boundsRight - boundsLeft) * nextMonitorWidth
+    val newWindowHeight = (boundsBottom - boundsTop) * nextMonitorHeight
+
+    User32.INSTANCE.SetWindowPos(
+      window,
+      null,
+      x.round.toInt,
+      y.round.toInt,
+      newWindowWidth.round.toInt,
+      newWindowHeight.round.toInt,
+      WinUser.SWP_NOZORDER
+    )
+
+    // HACK: When the DPIs of the monitors are different, Windows seems to automatically resize the window not respecting
+    // the width/height sent into SetWindowPos. You can even see that the window is initially the correct size when sent
+    // to the second monitor for a split second. After that Windows is resizing it.
+    //
+    // A temporary working is calling it SetWindowPos 2nd time. Once the window is on the right monitor, SetWindowPos
+    // works as expected. Ideally we find a "proper" solution for this though.
+    User32.INSTANCE.SetWindowPos(
+      window,
+      null,
+      x.round.toInt,
+      y.round.toInt,
+      newWindowWidth.round.toInt,
+      newWindowHeight.round.toInt,
+      WinUser.SWP_NOZORDER
+    )
+
+  }
+}
+
+final case class WindowBounds(left: Double, top: Double, right: Double, bottom: Double)
+
+final case class CycleWindowState(index: Int, lastAction: Option[String])

--- a/emulator-swing/src/main/scala/commandcenter/emulator/swing/Main.scala
+++ b/emulator-swing/src/main/scala/commandcenter/emulator/swing/Main.scala
@@ -4,7 +4,7 @@ import commandcenter.CCRuntime.Env
 import commandcenter.emulator.swing.shortcuts.LiveShortcuts
 import commandcenter.emulator.swing.ui.SwingTerminal
 import commandcenter.shortcuts.Shortcuts
-import commandcenter.{ shortcuts, CCApp, CCConfig, TerminalType }
+import commandcenter.{ shortcuts, CCApp, CCConfig, GlobalActions, TerminalType }
 import zio._
 import zio.logging.log
 
@@ -25,6 +25,7 @@ object Main extends CCApp {
                            } yield ()).ignore
                          )
                     _ <- log.debug("Ready to accept input")
+                    _ <- GlobalActions.setupCommon(config.globalActions)
                   } yield ()).toManaged_
     } yield ()).useForever.exitCode
 }

--- a/emulator-swing/src/main/scala/commandcenter/emulator/swing/ui/SwingTerminal.scala
+++ b/emulator-swing/src/main/scala/commandcenter/emulator/swing/ui/SwingTerminal.scala
@@ -369,7 +369,7 @@ final case class SwingTerminal(
 object SwingTerminal {
   def create(config: CCConfig, runtime: CCRuntime): Managed[Throwable, SwingTerminal] =
     for {
-      searchDebounce   <- Debounced[Env, Nothing, Unit](250.millis).toManaged_
+      searchDebounce   <- Debounced[Env, Nothing, Unit](200.millis).toManaged_
       commandCursorRef <- Ref.makeManaged(0)
       searchResultsRef <- Ref.makeManaged(SearchResults.empty[Any])
     } yield new SwingTerminal(config, commandCursorRef, searchResultsRef, searchDebounce)(runtime)

--- a/emulator-swt/src/main/scala/commandcenter/emulator/swt/Main.scala
+++ b/emulator-swt/src/main/scala/commandcenter/emulator/swt/Main.scala
@@ -3,7 +3,7 @@ package commandcenter.emulator.swt
 import commandcenter.emulator.swt.shortcuts.LiveShortcuts
 import commandcenter.emulator.swt.ui.{ RawSwtTerminal, SwtTerminal }
 import commandcenter.shortcuts.Shortcuts
-import commandcenter.{ shortcuts, CCConfig, CCRuntime, TerminalType }
+import commandcenter.{ shortcuts, CCConfig, CCRuntime, GlobalActions, TerminalType }
 import zio._
 import zio.logging.log
 
@@ -29,6 +29,7 @@ object Main {
                              } yield ()).ignore
                            )
                       _ <- log.debug("Ready to accept input")
+                      _ <- GlobalActions.setupCommon(config.globalActions)
                     } yield ()).toManaged_
       } yield ()).useForever.exitCode
     }

--- a/emulator-swt/src/main/scala/commandcenter/emulator/swt/ui/SwtTerminal.scala
+++ b/emulator-swt/src/main/scala/commandcenter/emulator/swt/ui/SwtTerminal.scala
@@ -296,7 +296,7 @@ final case class SwtTerminal(
 object SwtTerminal {
   def create(config: CCConfig, runtime: CCRuntime, terminal: RawSwtTerminal): ZManaged[Env, Throwable, SwtTerminal] =
     for {
-      searchDebounce   <- Debounced[Env, Nothing, Unit](250.millis).toManaged_
+      searchDebounce   <- Debounced[Env, Nothing, Unit](200.millis).toManaged_
       commandCursorRef <- Ref.makeManaged(0)
       searchResultsRef <- Ref.makeManaged(SearchResults.empty[Any])
       swtTerminal       = new SwtTerminal(config, commandCursorRef, searchResultsRef, searchDebounce, terminal)(runtime)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,11 +8,12 @@ object Build {
   val CommandCenterVersion = "0.0.1"
 
   object Version {
-    val zio   = "1.0.3"
-    val circe = "0.13.0"
-    val sttp  = "2.2.9"
-    val graal = "20.2.0"
-    val swt   = "3.115.100"
+    val zio        = "1.0.3"
+    val enumeratum = "1.6.1"
+    val circe      = "0.13.0"
+    val sttp       = "2.2.9"
+    val graal      = "20.2.0"
+    val swt        = "3.115.100"
 
     // If you set this to None you can test with your locally installed version of Graal. Otherwise it will run in Docker
     // and build a Linux image (e.g. setting it to s"$graal-java11").


### PR DESCRIPTION
Currently only supports Windows but other OSes will be coming in the future.

This introduces global shortcuts for a bunch of window management functions:
- Center the current window
- Move to next/previous display
- Maximize window
- Cycle window sizes in each direction. For example, pressing win+alt+right the first time will move+reszie the window to the right half of the screen. Pressing it again will resize it to 2/3 of the screen. And once more will be 1/3 of the screen. Then the cycle repeats.

More functions will be coming in the future.