### PR TITLE
Preliminary work for pagination support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,7 @@ lazy val core = module("core")
       "dev.zio"                      %% "zio-streams"            % Version.zio,
       "dev.zio"                      %% "zio-process"            % "0.4.0",
       "dev.zio"                      %% "zio-logging"            % "0.5.10",
+      "io.github.kitlangton"         %% "zio-magic"              % "0.3.2",
       "io.circe"                     %% "circe-config"           % "0.8.0",
       "org.scala-lang"                % "scala-reflect"          % "2.13.6",
       "io.circe"                     %% "circe-core"             % Version.circe,

--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,7 @@ lazy val strokeOrderPlugin = module("stroke-order-plugin", Some("extras/stroke-o
 
 lazy val jectPlugin = module("ject-plugin", Some("extras/ject"))
   .dependsOn(core)
-  .settings(libraryDependencies ++= Seq("com.github.reibitto" %% "ject" % "0.0.1"))
+  .settings(libraryDependencies ++= Seq("com.github.reibitto" %% "ject" % "0.1.0"))
 
 lazy val extras     = project
   .in(file("extras"))

--- a/cli/src/main/scala/commandcenter/cli/message/CCResponse.scala
+++ b/cli/src/main/scala/commandcenter/cli/message/CCResponse.scala
@@ -3,11 +3,12 @@ package commandcenter.cli.message
 import commandcenter.command.SearchResults
 import commandcenter.view.Rendered
 import io.circe._
+import zio.Chunk
 
 sealed trait CCResponse
 
 object CCResponse {
-  final case class Search(searchTerm: String, results: Vector[SearchResult]) extends CCResponse
+  final case class Search(searchTerm: String, results: Chunk[SearchResult]) extends CCResponse
 
   object Search {
     implicit val encoder: Encoder[Search] = Encoder.forProduct2("searchTerm", "results")(s => (s.searchTerm, s.results))

--- a/core/src/main/scala/commandcenter/command/DecodeBase64Command.scala
+++ b/core/src/main/scala/commandcenter/command/DecodeBase64Command.scala
@@ -14,14 +14,14 @@ final case class DecodeBase64Command(commandNames: List[String]) extends Command
   val commandType: CommandType = CommandType.DecodeBase64Command
   val title: String            = "Decode (Base64)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input                    <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       all                       = (stringArg, encodingOpt).tupled
       parsedCommand             = decline.Command("", s"Base64 decodes the given string")(all).parse(input.args)
       (valueToDecode, charset) <- ZIO.fromEither(parsedCommand).mapError(CommandError.CliError)
       decoded                   = new String(Base64.getDecoder.decode(valueToDecode.getBytes(charset)), charset)
-    } yield List(
+    } yield PreviewResults.one(
       Preview(decoded).onRun(tools.setClipboard(decoded)).score(Scores.high(input.context))
     )
 }

--- a/core/src/main/scala/commandcenter/command/DecodeUrlCommand.scala
+++ b/core/src/main/scala/commandcenter/command/DecodeUrlCommand.scala
@@ -14,14 +14,14 @@ final case class DecodeUrlCommand(commandNames: List[String]) extends Command[St
   val commandType: CommandType = CommandType.DecodeUrlCommand
   val title: String            = "Decode (URL)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input                    <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       all                       = (stringArg, encodingOpt).tupled
       parsedCommand             = decline.Command("", s"URL decodes the given string")(all).parse(input.args)
       (valueToDecode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       decoded                  <- Task(URLDecoder.decode(valueToDecode, charset)).mapError(CommandError.UnexpectedException)
-    } yield List(
+    } yield PreviewResults.one(
       Preview(decoded).onRun(tools.setClipboard(decoded)).score(Scores.high(input.context))
     )
 }

--- a/core/src/main/scala/commandcenter/command/EncodeBase64Command.scala
+++ b/core/src/main/scala/commandcenter/command/EncodeBase64Command.scala
@@ -14,14 +14,14 @@ final case class EncodeBase64Command(commandNames: List[String]) extends Command
   val commandType: CommandType = CommandType.EncodeBase64Command
   val title: String            = "Encode (Base64)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input                    <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       all                       = (stringArg, encodingOpt).tupled
       parsedCommand             = decline.Command("", s"Base64 encodes the given string")(all).parse(input.args)
       (valueToEncode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       encoded                   = Base64.getEncoder.encodeToString(valueToEncode.getBytes(charset))
-    } yield List(
+    } yield PreviewResults.one(
       Preview(encoded).onRun(tools.setClipboard(encoded)).score(Scores.high(input.context))
     )
 }

--- a/core/src/main/scala/commandcenter/command/EncodeUrlCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EncodeUrlCommand.scala
@@ -15,14 +15,14 @@ final case class EncodeUrlCommand(commandNames: List[String]) extends Command[St
 
   val title: String = "Encode (URL)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input                    <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       all                       = (stringArg, encodingOpt).tupled
       parsedCommand             = decline.Command("", s"URL encodes the given string")(all).parse(input.args)
       (valueToEncode, charset) <- IO.fromEither(parsedCommand).mapError(CommandError.CliError)
       encoded                   = URLEncoder.encode(valueToEncode, charset)
-    } yield List(
+    } yield PreviewResults.one(
       Preview(encoded).onRun(tools.setClipboard(encoded)).score(Scores.high(input.context))
     )
 }

--- a/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochMillisCommand.scala
@@ -13,7 +13,7 @@ final case class EpochMillisCommand(commandNames: List[String]) extends Command[
   val commandType: CommandType = CommandType.EpochMillisCommand
   val title: String            = "Epoch (milliseconds)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input           <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
       (output, score) <- if (input.rest.trim.isEmpty) {
@@ -39,7 +39,7 @@ final case class EpochMillisCommand(commandNames: List[String]) extends Command[
                              case None => ZIO.fail(CommandError.NotApplicable)
                            }
                          }
-    } yield List(
+    } yield PreviewResults.one(
       Preview(output)
         .score(score)
         .onRun(tools.setClipboard(output))

--- a/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/EpochUnixCommand.scala
@@ -13,7 +13,7 @@ final case class EpochUnixCommand(commandNames: List[String]) extends Command[St
   val commandType: CommandType = CommandType.EpochUnixCommand
   val title: String            = "Epoch (Unix time)"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input           <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
       (output, score) <- if (input.rest.trim.isEmpty) {
@@ -39,7 +39,7 @@ final case class EpochUnixCommand(commandNames: List[String]) extends Command[St
                              case None => ZIO.fail(CommandError.NotApplicable)
                            }
                          }
-    } yield List(
+    } yield PreviewResults.one(
       Preview(output)
         .score(score)
         .onRun(tools.setClipboard(output))

--- a/core/src/main/scala/commandcenter/command/ExitCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ExitCommand.scala
@@ -9,10 +9,12 @@ final case class ExitCommand(commandNames: List[String]) extends Command[Command
   val commandType: CommandType = CommandType.ExitCommand
   val title: String            = "Exit Command Center"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[CommandResult]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[CommandResult]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-    } yield List(Preview(CommandResult.Exit).view(DefaultView(title, "")).score(Scores.high(input.context)))
+    } yield PreviewResults.one(
+      Preview(CommandResult.Exit).view(DefaultView(title, "")).score(Scores.high(input.context))
+    )
 }
 
 object ExitCommand extends CommandPlugin[ExitCommand] {

--- a/core/src/main/scala/commandcenter/command/ExternalIPCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ExternalIPCommand.scala
@@ -12,11 +12,11 @@ final case class ExternalIPCommand(commandNames: List[String]) extends Command[S
   val commandType: CommandType = CommandType.ExternalIPCommand
   val title: String            = "External IP"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input      <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
       externalIP <- getExternalIP
-    } yield List(
+    } yield PreviewResults.one(
       Preview(externalIP)
         .score(Scores.high(input.context))
         .onRun(tools.setClipboard(externalIP))

--- a/core/src/main/scala/commandcenter/command/FindInFileCommand.scala
+++ b/core/src/main/scala/commandcenter/command/FindInFileCommand.scala
@@ -16,7 +16,7 @@ final case class FindInFileCommand(commandNames: List[String]) extends Command[F
 
   override val supportedOS: Set[OS] = Set(OS.MacOS)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[File]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[File]] =
     for {
       input  <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
       // TODO: mdfind/Spotlight can be really slow, especially when there are a lot of matches. Streaming the top N results
@@ -35,7 +35,7 @@ final case class FindInFileCommand(commandNames: List[String]) extends Command[F
                                   .onRun(PCommand("open", file.getAbsolutePath).exitCode.unit)
                                   .score(Scores.high(input.context))
                               }
-                  } yield results).mapError(UnexpectedException)
+                  } yield PreviewResults.fromIterable(results)).mapError(UnexpectedException)
     } yield result
 }
 

--- a/core/src/main/scala/commandcenter/command/HashCommand.scala
+++ b/core/src/main/scala/commandcenter/command/HashCommand.scala
@@ -16,7 +16,7 @@ final case class HashCommand(algorithm: String) extends Command[String] {
   val commandNames: List[String] = List(algorithm, algorithm.replace("-", "")).distinct
   val title: String              = algorithm
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input                  <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       all                     = (stringArg, encodingOpt).tupled
@@ -25,7 +25,7 @@ final case class HashCommand(algorithm: String) extends Command[String] {
       hashResult             <- IO
                                   .fromEither(HashUtil.hash(algorithm)(valueToHash, charset))
                                   .mapError(CommandError.UnexpectedException)
-    } yield List(
+    } yield PreviewResults.one(
       Preview(hashResult)
         .score(Scores.high(input.context))
         .onRun(tools.setClipboard(hashResult))

--- a/core/src/main/scala/commandcenter/command/ITunesCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ITunesCommand.scala
@@ -57,7 +57,7 @@ final case class ITunesCommand(commandNames: List[String]) extends Command[Unit]
   val rateTrackFn     = AppleScript.loadFunction1[Int]("applescript/itunes/rate.applescript")
   val deleteTrackFn   = AppleScript.loadFunction0("applescript/itunes/delete-track.applescript")
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = itunesCommand.parse(input.args)
@@ -109,7 +109,7 @@ final case class ITunesCommand(commandNames: List[String]) extends Command[Unit]
                }
       } yield ()
 
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/LocalIPCommand.scala
+++ b/core/src/main/scala/commandcenter/command/LocalIPCommand.scala
@@ -15,7 +15,7 @@ final case class LocalIPCommand(commandNames: List[String]) extends Command[Stri
   val commandType: CommandType = CommandType.LocalIPCommand
   val title: String            = "Local IP"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       input    <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
       localIps <- effectBlocking {
@@ -28,12 +28,12 @@ final case class LocalIPCommand(commandNames: List[String]) extends Command[Stri
                         }
                       }
                   }.mapError(CommandError.UnexpectedException)
-    } yield localIps.map { case (interfaceName, localIp) =>
+    } yield PreviewResults.fromIterable(localIps.map { case (interfaceName, localIp) =>
       Preview(localIp)
         .onRun(tools.setClipboard(localIp))
         .score(Scores.high(input.context))
         .view(DefaultView(title, fansi.Str(interfaceName) ++ fansi.Str(": ") ++ fansi.Color.Magenta(localIp)))
-    }
+    })
 }
 
 object LocalIPCommand extends CommandPlugin[LocalIPCommand] {

--- a/core/src/main/scala/commandcenter/command/LockCommand.scala
+++ b/core/src/main/scala/commandcenter/command/LockCommand.scala
@@ -14,10 +14,10 @@ final case class LockCommand(commandNames: List[String]) extends Command[Unit] {
 
   override val supportedOS: Set[OS] = Set(OS.MacOS, OS.Windows)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-    } yield List(
+    } yield PreviewResults.one(
       Preview.unit.onRun(pCommand.exitCode.unit).score(Scores.high(input.context))
     )
 

--- a/core/src/main/scala/commandcenter/command/LoremIpsumCommand.scala
+++ b/core/src/main/scala/commandcenter/command/LoremIpsumCommand.scala
@@ -30,7 +30,7 @@ final case class LoremIpsumCommand(commandNames: List[String], lipsum: String) e
 
   val lipsumCommand = decline.Command(title, title)((numOpt, typeOpt).tupled)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = lipsumCommand.parse(input.args)
@@ -53,7 +53,7 @@ final case class LoremIpsumCommand(commandNames: List[String], lipsum: String) e
                           }
         _              <- tools.setClipboard(text)
       } yield ()
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/OpacityCommand.scala
+++ b/core/src/main/scala/commandcenter/command/OpacityCommand.scala
@@ -15,7 +15,7 @@ final case class OpacityCommand(commandNames: List[String]) extends Command[Unit
 
   val opacityCommand = decline.Command("opacity", title)(opacity)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       _              <- ZIO.fail(CommandError.NotApplicable).unlessM(searchInput.context.terminal.isOpacitySupported)
       input          <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
@@ -30,7 +30,7 @@ final case class OpacityCommand(commandNames: List[String]) extends Command[Unit
         _       <- input.context.terminal.setOpacity(opacity)
       } yield ()
 
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/OpenBrowserCommand.scala
+++ b/core/src/main/scala/commandcenter/command/OpenBrowserCommand.scala
@@ -13,14 +13,14 @@ final case class OpenBrowserCommand() extends Command[Unit] {
 
   val title: String = "Open in Browser"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] = {
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] = {
     val input      = searchInput.input
     val startsWith = input.startsWith("http://") || input.startsWith("https://")
 
     // TODO: also check endsWith TLD + URL.isValid
 
     if (startsWith)
-      UIO(List(Preview.unit.onRun(ProcessUtil.openBrowser(input))))
+      UIO(PreviewResults.one(Preview.unit.onRun(ProcessUtil.openBrowser(input))))
     else
       IO.fail(NotApplicable)
   }

--- a/core/src/main/scala/commandcenter/command/PreviewResults.scala
+++ b/core/src/main/scala/commandcenter/command/PreviewResults.scala
@@ -1,0 +1,24 @@
+package commandcenter.command
+
+import zio.Chunk
+import zio.stream.ZStream
+
+sealed trait PreviewResults[+R]
+
+object PreviewResults {
+  def one[R](result: PreviewResult[R]): PreviewResults[R] =
+    PreviewResults.Single(result)
+
+  def fromIterable[R](results: Iterable[PreviewResult[R]]): PreviewResults[R] =
+    PreviewResults.Multiple(Chunk.fromIterable(results))
+
+  def paginated[A](stream: ZStream[Any, CommandError, PreviewResult[A]], pageSize: Int): PreviewResults[A] =
+    PreviewResults.Paginated(stream, pageSize)
+
+  final case class Single[R](result: PreviewResult[R]) extends PreviewResults[R]
+
+  final case class Multiple[R](results: Chunk[PreviewResult[R]]) extends PreviewResults[R]
+
+  final case class Paginated[R](results: ZStream[Any, CommandError, PreviewResult[R]], pageSize: Int)
+      extends PreviewResults[R]
+}

--- a/core/src/main/scala/commandcenter/command/RadixCommand.scala
+++ b/core/src/main/scala/commandcenter/command/RadixCommand.scala
@@ -21,7 +21,7 @@ final case class RadixCommand(commandNames: List[String]) extends Command[Unit] 
 
   val radixCommand = decline.Command("radix", title)((fromRadixOpt, toRadixOpt, numberArg).tupled)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = radixCommand.parse(input.args)
@@ -47,7 +47,7 @@ final case class RadixCommand(commandNames: List[String]) extends Command[Unit] 
                        }
                      }
                    )
-    } yield List(preview)
+    } yield PreviewResults.one(preview)
 
 }
 

--- a/core/src/main/scala/commandcenter/command/RebootCommand.scala
+++ b/core/src/main/scala/commandcenter/command/RebootCommand.scala
@@ -12,20 +12,22 @@ final case class RebootCommand(commandNames: List[String]) extends Command[Unit]
   val commandType: CommandType = CommandType.RebootCommand
   val title: String            = "Reboot"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-    } yield List(
-      Preview.unit
-        .onRun(RebootCommand.reboot)
-        .score(Scores.high(input.context))
-        .view(DefaultView(title, "Restart your computer"))
-    ) ++ List(
-      Preview.unit
-        .onRun(RebootCommand.rebootIntoBios)
-        .score(Scores.high(input.context))
-        .view(DefaultView(s"$title (into BIOS setup)", "Restart your computer and enter BIOS upon startup"))
-    ).filter(_ => OS.os == OS.Windows || OS.os == OS.Linux)
+    } yield PreviewResults.fromIterable(
+      Vector(
+        Preview.unit
+          .onRun(RebootCommand.reboot)
+          .score(Scores.high(input.context))
+          .view(DefaultView(title, "Restart your computer"))
+      ) ++ Vector(
+        Preview.unit
+          .onRun(RebootCommand.rebootIntoBios)
+          .score(Scores.high(input.context))
+          .view(DefaultView(s"$title (into BIOS setup)", "Restart your computer and enter BIOS upon startup"))
+      ).filter(_ => OS.os == OS.Windows || OS.os == OS.Linux)
+    )
 }
 
 object RebootCommand extends CommandPlugin[RebootCommand] {

--- a/core/src/main/scala/commandcenter/command/ReloadCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ReloadCommand.scala
@@ -9,10 +9,10 @@ final case class ReloadCommand(commandNames: List[String]) extends Command[Unit]
   val commandType: CommandType = CommandType.ResizeCommand
   val title: String            = "Reload Config"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
-    } yield List(
+    } yield PreviewResults.one(
       Preview.unit
         .onRun(input.context.terminal.reload.orDie)
         .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/ResizeCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ResizeCommand.scala
@@ -17,7 +17,7 @@ final case class ResizeCommand(commandNames: List[String]) extends Command[Unit]
 
   val resizeCommand = decline.Command("resize", title)((width, height).tupled)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = resizeCommand.parse(input.args)
@@ -35,7 +35,7 @@ final case class ResizeCommand(commandNames: List[String]) extends Command[Unit]
         _      <- input.context.terminal.setSize(w, h)
       } yield ()
 
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run.orDie)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/SearchResults.scala
+++ b/core/src/main/scala/commandcenter/command/SearchResults.scala
@@ -1,14 +1,19 @@
 package commandcenter.command
 
 import commandcenter.view.Rendered
+import zio.Chunk
 
-final case class SearchResults[R](searchTerm: String, previews: Vector[PreviewResult[R]]) {
-  lazy val rendered: Vector[Rendered] = previews.map(_.renderFn())
+final case class SearchResults[R](
+  searchTerm: String,
+  previews: Chunk[PreviewResult[R]],
+  errors: Chunk[CommandError] = Chunk.empty
+) {
+  lazy val rendered: Chunk[Rendered] = previews.map(_.renderFn())
 
   def hasChange(otherSearchTerm: String): Boolean =
     searchTerm.trim != otherSearchTerm.trim
 }
 
 object SearchResults {
-  def empty[R]: SearchResults[R] = SearchResults("", Vector.empty)
+  def empty[R]: SearchResults[R] = SearchResults("", Chunk.empty)
 }

--- a/core/src/main/scala/commandcenter/command/SnippetsCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SnippetsCommand.scala
@@ -13,12 +13,12 @@ final case class SnippetsCommand(commandNames: List[String], snippets: List[Snip
   val commandType: CommandType = CommandType.SnippetsCommand
   val title: String            = "Snippets"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[String]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[String]] =
     for {
       (isPrefixed, snippetSearch) <-
         ZIO.fromOption(searchInput.asPrefixed).bimap(_ => (false, searchInput.input), s => (true, s.rest)).merge
 
-    } yield snippets.map { snip =>
+    } yield PreviewResults.fromIterable(snippets.map { snip =>
       val score =
         if (isPrefixed)
           Scores.high(searchInput.context)
@@ -35,7 +35,7 @@ final case class SnippetsCommand(commandNames: List[String], snippets: List[Snip
           .onRun(tools.setClipboard(snippet.value))
           .score(score)
           .view(DefaultView(title, fansi.Color.Magenta(snippet.keyword) ++ " " ++ snippet.value))
-    }
+    })
 }
 
 object SnippetsCommand extends CommandPlugin[SnippetsCommand] {

--- a/core/src/main/scala/commandcenter/command/SuspendProcessCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SuspendProcessCommand.scala
@@ -21,7 +21,7 @@ final case class SuspendProcessCommand(commandNames: List[String]) extends Comma
 
   val command = decline.Command("suspend", title)(Opts.argument[Long]("pid"))
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input        <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsedCommand = command.parse(input.args)
@@ -35,7 +35,7 @@ final case class SuspendProcessCommand(commandNames: List[String]) extends Comma
         _           <- SuspendProcessCommand.setProcessState(!isSuspended, pid)
       } yield ()
 
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run.orDie)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/SwitchWindowCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SwitchWindowCommand.scala
@@ -12,7 +12,7 @@ final case class SwitchWindowCommand(commandNames: List[String]) extends Command
   // TODO: Support macOS and Linux too
   override val supportedOS: Set[OS] = Set(OS.Windows)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
       // TODO: Consider adding more info than just the title. Like "File Explorer" and so on.
@@ -20,12 +20,12 @@ final case class SwitchWindowCommand(commandNames: List[String]) extends Command
                    CommandError.UnexpectedException,
                    _.tail.filter(_.title.contains(input.rest))
                  )
-    } yield windows.map { w =>
+    } yield PreviewResults.fromIterable(windows.map { w =>
       Preview.unit
         .onRun(WindowManager.giveWindowFocus(w.window))
         .score(Scores.high(input.context))
         .view(fansi.Color.Cyan(w.title))
-    }
+    })
 }
 
 object SwitchWindowCommand extends CommandPlugin[SwitchWindowCommand] {

--- a/core/src/main/scala/commandcenter/command/SystemCommand.scala
+++ b/core/src/main/scala/commandcenter/command/SystemCommand.scala
@@ -35,7 +35,7 @@ final case class SystemCommand(commandNames: List[String]) extends Command[Unit]
   val SC_MONITORPOWER: Int = 0xf170
   val SC_SCREENSAVE: Int   = 0xf140
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = systemCommand.parse(input.args)
@@ -94,7 +94,7 @@ final case class SystemCommand(commandNames: List[String]) extends Command[Unit]
                        Preview.unit.onRun(run).view(view).score(Scores.high(input.context))
                      }
                    )
-    } yield List(preview)
+    } yield PreviewResults.one(preview)
 }
 
 object SystemCommand extends CommandPlugin[SystemCommand] {

--- a/core/src/main/scala/commandcenter/command/TemperatureCommand.scala
+++ b/core/src/main/scala/commandcenter/command/TemperatureCommand.scala
@@ -18,7 +18,7 @@ final case class TemperatureCommand() extends Command[Double] {
 
   val temperatureRegex: Regex = """(-?\d+\.?\d*)\s*([cCＣfFＦ度どド])""".r
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Double]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Double]] =
     for {
       (temperature, unit) <- ZIO.fromOption {
                                temperatureRegex.unapplySeq(searchInput.input.trim).flatMap {
@@ -39,7 +39,7 @@ final case class TemperatureCommand() extends Command[Double] {
                                }
                              }.orElseFail(NotApplicable)
       temperatureFormatted = f"$temperature%.1f $unit"
-    } yield List(
+    } yield PreviewResults.one(
       Preview(temperature)
         .score(Scores.high(searchInput.context))
         .view(DefaultView(title, temperatureFormatted))

--- a/core/src/main/scala/commandcenter/command/TerminalCommand.scala
+++ b/core/src/main/scala/commandcenter/command/TerminalCommand.scala
@@ -10,10 +10,10 @@ final case class TerminalCommand(commandNames: List[String]) extends Command[Uni
   val commandType: CommandType = CommandType.TerminalCommand
   val title: String            = "Terminal"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asPrefixed).orElseFail(CommandError.NotApplicable)
-    } yield List(Preview.unit.view(DefaultView("Terminal", input.rest)).score(Scores.high(input.context)))
+    } yield PreviewResults.one(Preview.unit.view(DefaultView("Terminal", input.rest)).score(Scores.high(input.context)))
 }
 
 object TerminalCommand extends CommandPlugin[TerminalCommand] {

--- a/core/src/main/scala/commandcenter/command/TimerCommand.scala
+++ b/core/src/main/scala/commandcenter/command/TimerCommand.scala
@@ -31,7 +31,7 @@ final case class TimerCommand(commandNames: List[String]) extends Command[Unit] 
   // TODO: Support all OSes
   override val supportedOS: Set[OS] = Set(OS.MacOS, OS.Windows)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input   <- ZIO.fromOption(searchInput.asArgs).orElseFail(CommandError.NotApplicable)
       parsed   = timerCommand.parse(input.args)
@@ -46,7 +46,7 @@ final case class TimerCommand(commandNames: List[String]) extends Command[Unit] 
         _                        <- notifyFn(timerDoneMessage, "Command Center Timer Event").delay(delay)
       } yield ()
 
-      List(
+      PreviewResults.one(
         Preview.unit
           .onRun(run)
           .score(Scores.high(input.context))

--- a/core/src/main/scala/commandcenter/command/ToggleDesktopIconsCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ToggleDesktopIconsCommand.scala
@@ -12,7 +12,7 @@ final case class ToggleDesktopIconsCommand(commandNames: List[String]) extends C
 
   override val supportedOS: Set[OS] = Set(OS.MacOS)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
     } yield {
@@ -23,7 +23,7 @@ final case class ToggleDesktopIconsCommand(commandNames: List[String]) extends C
         _            <- PCommand("killall", "Finder").exitCode
       } yield ()
 
-      List(Preview.unit.onRun(run).score(Scores.high(input.context)))
+      PreviewResults.one(Preview.unit.onRun(run).score(Scores.high(input.context)))
     }
 }
 

--- a/core/src/main/scala/commandcenter/command/ToggleHiddenFilesCommand.scala
+++ b/core/src/main/scala/commandcenter/command/ToggleHiddenFilesCommand.scala
@@ -13,7 +13,7 @@ final case class ToggleHiddenFilesCommand(commandNames: List[String]) extends Co
 
   override val supportedOS: Set[OS] = Set(OS.MacOS, OS.Windows)
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
     } yield {
@@ -22,7 +22,7 @@ final case class ToggleHiddenFilesCommand(commandNames: List[String]) extends Co
         case _        => runWindows
       }
 
-      List(Preview.unit.onRun(run).score(Scores.high(input.context)))
+      PreviewResults.one(Preview.unit.onRun(run).score(Scores.high(input.context)))
     }
 
   private def runMacOS: ZIO[Blocking, PCommandError, Unit] =

--- a/core/src/main/scala/commandcenter/command/UUIDCommand.scala
+++ b/core/src/main/scala/commandcenter/command/UUIDCommand.scala
@@ -11,11 +11,11 @@ final case class UUIDCommand(commandNames: List[String]) extends Command[UUID] {
   val commandType: CommandType = CommandType.UUIDCommand
   val title: String            = "UUID"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[UUID]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[UUID]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
       uuid   = UUID.randomUUID()
-    } yield List(
+    } yield PreviewResults.one(
       Preview(uuid).onRun(tools.setClipboard(uuid.toString)).score(Scores.high(input.context))
     )
 }

--- a/core/src/main/scala/commandcenter/command/WorldTimesCommand.scala
+++ b/core/src/main/scala/commandcenter/command/WorldTimesCommand.scala
@@ -15,12 +15,12 @@ final case class WorldTimesCommand(commandNames: List[String], dateTimeFormat: S
   val commandType: CommandType = CommandType.WorldTimesCommand
   val title: String            = "World Times"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asKeyword).orElseFail(CommandError.NotApplicable)
       now    = OffsetDateTime.now
       times  = zones.map(tz => WorldTimesResult(tz.zoneId, tz.displayName, now.atZoneSameInstant(tz.zoneId)))
-    } yield List(
+    } yield PreviewResults.one(
       Preview.unit.view(WorldTimesResults(dateTimeFormat, times, input.context)).score(Scores.high(input.context))
     )
 }

--- a/core/src/test/scala/commandcenter/CommandBaseSpec.scala
+++ b/core/src/test/scala/commandcenter/CommandBaseSpec.scala
@@ -1,27 +1,29 @@
 package commandcenter
 
 import java.util.Locale
-
 import commandcenter.TestRuntime.TestEnv
 import commandcenter.command.cache.InMemoryCache
 import commandcenter.shortcuts.Shortcuts
 import commandcenter.tools.Tools
 import sttp.client.httpclient.zio.HttpClientZioBackend
-import zio.Layer
+import zio.{ Layer, ZLayer }
 import zio.duration._
 import zio.test.environment.testEnvironment
 import zio.test.{ RunnableSpec, TestAspect, TestExecutor, TestRunner }
 
 trait CommandBaseSpec extends RunnableSpec[TestEnv, Any] {
-  val testEnv: Layer[Throwable, TestEnv] =
-    testEnvironment >>> (
-      testEnvironment
-        ++ CCLogging.make(TerminalType.Test)
-        ++ Tools.live
-        ++ Shortcuts.unsupported
-        ++ HttpClientZioBackend.layer()
-        ++ InMemoryCache.make(5.minutes)
+  val testEnv: Layer[Throwable, TestEnv] = {
+    import zio.magic._
+
+    ZLayer.fromMagic[TestEnv](
+      testEnvironment,
+      CCLogging.make(TerminalType.Test),
+      Tools.live,
+      Shortcuts.unsupported,
+      HttpClientZioBackend.layer(),
+      InMemoryCache.make(5.minutes)
     )
+  }
 
   val defaultCommandContext: CommandContext =
     CommandContext(Locale.ENGLISH, TestTerminal, 1.0)

--- a/core/src/test/scala/commandcenter/SearchSpec.scala
+++ b/core/src/test/scala/commandcenter/SearchSpec.scala
@@ -16,7 +16,7 @@ object SearchSpec extends CommandBaseSpec {
 
     def title: String = "Exit"
 
-    def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+    def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
       ZIO.dieMessage("This command is broken!")
   }
 

--- a/extras/stroke-order/src/main/scala/commandcenter/strokeorder/StrokeOrderCommand.scala
+++ b/extras/stroke-order/src/main/scala/commandcenter/strokeorder/StrokeOrderCommand.scala
@@ -11,10 +11,10 @@ final case class StrokeOrderCommand(commandNames: List[String]) extends Command[
   val commandType: CommandType = CommandType.External(getClass.getCanonicalName)
   val title: String            = "Stroke Order"
 
-  def preview(searchInput: SearchInput): ZIO[Env, CommandError, List[PreviewResult[Unit]]] =
+  def preview(searchInput: SearchInput): ZIO[Env, CommandError, PreviewResults[Unit]] =
     for {
       input <- ZIO.fromOption(searchInput.asPrefixed.filter(_.rest.nonEmpty)).orElseFail(CommandError.NotApplicable)
-    } yield List(
+    } yield PreviewResults.one(
       Preview.unit
         .score(Scores.high(searchInput.context))
         .onRun(tools.setClipboard(input.rest))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,9 +59,9 @@ object Build {
     Seq(
       name := projectName,
       version := CommandCenterVersion,
-      javaOptions in Test += "-Duser.timezone=UTC",
+      Test / javaOptions += "-Duser.timezone=UTC",
       scalacOptions := ScalacOptions,
-      scalaVersion in ThisBuild := ScalaVersion,
+      ThisBuild / scalaVersion := ScalaVersion,
       unmanagedBase := baseDirectory.value / "plugins",
       libraryDependencies ++= Plugins.BaseCompilerPlugins,
       libraryDependencies ++= Seq(
@@ -72,8 +72,8 @@ object Build {
       autoAPIMappings := true,
       resolvers := Resolvers,
       testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")),
-      fork in Test := true,
-      logBuffered in Test := false
+      Test / fork := true,
+      Test / logBuffered := false
     )
 
   lazy val Resolvers = Seq(


### PR DESCRIPTION
Part of #107

This adds a `PreviewResults` ADT which can also accept a stream. This will be used to support pagination. For now only the first page is shown. The next step is to add a UI element (like a "Load more..." button) that will fetch the next page and show it in the results list.